### PR TITLE
Store left/right strips of an IBC wavefunction by reference to a file

### DIFF
--- a/wavefunction/ibc.h
+++ b/wavefunction/ibc.h
@@ -129,7 +129,13 @@ class IBCWavefunction
 
       int window_offset() const { return WindowOffset; }
 
+      // Return the filename of the left/right windows.  If this is empty then the
+      // wavefunctions are stored directly in this object
+      std::string LeftWindowFile() const { return WavefunctionLeftFile; }
+      std::string RightWindowFile() const { return WavefunctionRightFile; }
+
       void SetDefaultAttributes(AttributeList& A) const;
+
 
       static std::string const Type;
 
@@ -150,6 +156,10 @@ class IBCWavefunction
 
       int WindowOffset;  // site index of the first site of the Window
 
+      // We can optionally save the left and right semi-infinite wavefunctions on disc by reference to a file.
+      // If these strings are non-empty then the Left and Right components are not saved when this wavefunction
+      // is streamed to disc.
+      std::string WavefunctionLeftFile, WavefunctionRightFile;
       InfiniteWavefunctionLeft Left;
       WavefunctionSectionLeft Window;
       InfiniteWavefunctionRight Right;

--- a/wavefunction/infinitewavefunctionright.cpp
+++ b/wavefunction/infinitewavefunctionright.cpp
@@ -40,6 +40,8 @@ extern double const ArnoldiTol;
 extern double const InverseTol;
 extern double const OrthoTol;
 
+std::string InfiniteWavefunctionRight::Type = "InfiniteWavefunctionRight";
+
 PStream::VersionTag
 InfiniteWavefunctionRight::VersionT(1);
 
@@ -376,6 +378,14 @@ InfiniteWavefunctionRight::rotate_right(int Count)
 }
 
 void
+InfiniteWavefunctionRight::SetDefaultAttributes(AttributeList& A) const
+{
+   A["WavefunctionType"] = "InfiniteRightCanonical";
+   A["UnitCellSize"] = this->size();
+   A["QShift"] = this->qshift();
+}
+
+void
 InfiniteWavefunctionRight::check_structure() const
 {
    this->CanonicalWavefunctionBase::check_structure();
@@ -393,6 +403,11 @@ void inplace_conj(InfiniteWavefunctionRight& Psi)
 
 InfiniteWavefunctionRight
 reflect(InfiniteWavefunctionLeft const& Psi)
+{
+   PANIC("not implemented");
+}
+
+void inplace_reflect(InfiniteWavefunctionRight& Psi)
 {
    PANIC("not implemented");
 }

--- a/wavefunction/infinitewavefunctionright.h
+++ b/wavefunction/infinitewavefunctionright.h
@@ -68,6 +68,10 @@ class InfiniteWavefunctionRight : public CanonicalWavefunctionBase
       // returns the orthogonality fidelity.  Normally this should be epsilon
       double orthogonality_fidelity() const;
 
+      void SetDefaultAttributes(AttributeList& A) const;
+
+      static std::string Type;
+
       static PStream::VersionTag VersionT;
 
       friend PStream::ipstream& operator>>(PStream::ipstream& in,

--- a/wavefunction/mpwavefunction.cpp
+++ b/wavefunction/mpwavefunction.cpp
@@ -19,7 +19,7 @@
 
 #include "mpwavefunction.h"
 
-// default version is 6.
+// default version is 7.
 //
 // Versions 1 and 2 don't contain an AttributeList (although older versions of
 // InfiniteWavefunction do, but it isn't used anywhere so no need to keep it).
@@ -51,8 +51,13 @@
 // boost::variant<InfiniteWavefunctionLeft, IBCWavefunction, FiniteWavefunctionLeft>
 // AttributeList
 // HistoryLog
+//
+// Version 6:
+// boost::variant<InfiniteWavefunctionLeft, IBCWavefunction, FiniteWavefunctionLeft, InfiniteWavefunctionRight>
+// AttributeList
+// HistoryLog
 
-PStream::VersionTag MPWavefunction::VersionT(6);
+PStream::VersionTag MPWavefunction::VersionT(7);
 
 PStream::ipstream&
 operator>>(PStream::ipstream& in, MPWavefunction& Psi)
@@ -116,6 +121,12 @@ void read_version(PStream::ipstream& in, MPWavefunction& Psi, int Version)
    else if (Version == 6)
    {
       boost::variant<InfiniteWavefunctionLeft, IBCWavefunction, FiniteWavefunctionLeft> x;
+      in >> x;
+      Psi.Psi_ = x;
+   }
+   else if (Version == 7)
+   {
+      boost::variant<InfiniteWavefunctionLeft, IBCWavefunction, FiniteWavefunctionLeft, InfiniteWavefunctionRight> x;
       in >> x;
       Psi.Psi_ = x;
    }

--- a/wavefunction/mpwavefunction.h
+++ b/wavefunction/mpwavefunction.h
@@ -25,6 +25,7 @@
 #define MPTOOLKIT_WAVEFUNCTION_MPWAVEFUNCTION_H
 
 #include "infinitewavefunctionleft.h"
+#include "infinitewavefunctionright.h"
 #include "ibc.h"
 #include "finitewavefunctionleft.h"
 #include <boost/variant.hpp>
@@ -35,7 +36,8 @@
 
 typedef boost::variant<InfiniteWavefunctionLeft,
 		       IBCWavefunction,
-		       FiniteWavefunctionLeft> WavefunctionTypes;
+		       FiniteWavefunctionLeft,
+				 InfiniteWavefunctionRight> WavefunctionTypes;
 
 class InvalidWavefunction : public std::runtime_error
 {


### PR DESCRIPTION
Issues:

- There is currently no way to actually create such a wavefunction.
- It will certainly exercise the disk I/O code since it will need to load an object from a different file in the middle of loading an IBC wavefunction.  In principle it will work but there might be bugs, as I'm not sure that this has been done before.
- There aren't any tools yet to create an InfiniteWavefunctionRight