### PR TITLE
Add mp-right-canonicalize

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -223,7 +223,7 @@ tools = mp-idmrg-s3e mp-ioverlap \
         mp-idivide mp-ies mp-irepeat mp-norm mp-allcorrelation \
         mp-irotate mp-icorrelation mp-fluctuation mp-itebd mp-coarsegrain mp-finegrain mp-dmrg mp-random \
         mp-expectation mp-overlap mp-scale mp-matrix mp-tebd mp-apply mp-normalize \
-				mp-iexpectation-cross mp-imoments-cross
+				mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize
 
 experimental-tools = mp-iprint mp-iproject mp-idmrg mp-iupdate mp-ibc-create mp-aux-project mp-ibc-dmrg
 

--- a/mp/mp-right-canonicalize.cpp
+++ b/mp/mp-right-canonicalize.cpp
@@ -1,0 +1,135 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://physics.uq.edu.au/people/ianmcc/mptoolkit/
+//
+// mp/mp-right-canonicalize.cpp
+//
+// Copyright (C) 2022 Jesse Osborne <j.osborne@uqconnect.edu.au>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Reseach publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#include "common/environment.h"
+#include "common/formatting.h"
+#include "common/prog_opt_accum.h"
+#include "common/prog_options.h"
+#include "common/terminal.h"
+#include "interface/inittemp.h"
+#include "mp/copyright.h"
+#include "wavefunction/mpwavefunction.h"
+
+namespace prog_opt = boost::program_options;
+
+int main(int argc, char** argv)
+{
+   try
+   {
+      int Verbose = 0;
+      bool Force = false;
+      std::string InputFile;
+      std::string OutputFile;
+
+      prog_opt::options_description desc("Allowed options", terminal::columns());
+      desc.add_options()
+         ("help", "Show this help message")
+         ("force,f", prog_opt::bool_switch(&Force), "Allow overwriting output files")
+         ("verbose,v",  prog_opt_ext::accum_value(&Verbose), "Increase verbosity (can be used more than once)")
+         ;
+
+      prog_opt::options_description hidden("Hidden options");
+      hidden.add_options()
+         ("psi1", prog_opt::value(&InputFile), "psi1")
+         ("psi2", prog_opt::value(&OutputFile), "psi2")
+         ;
+
+      prog_opt::positional_options_description p;
+      p.add("psi1", 1);
+      p.add("psi2", 1);
+
+      prog_opt::options_description opt;
+      opt.add(desc).add(hidden);
+
+      prog_opt::variables_map vm;
+      prog_opt::store(prog_opt::command_line_parser(argc, argv).
+                      options(opt).positional(p).run(), vm);
+      prog_opt::notify(vm);
+
+      if (vm.count("help") || vm.count("psi2") == 0)
+      {
+         print_copyright(std::cerr, "tools", basename(argv[0]));
+         std::cerr << "usage: " << basename(argv[0]) << " [options] <input-psi> <output-psi>" << std::endl;
+         std::cerr << desc << std::endl;
+         std::cerr << "This tool transforms an iMPS from left-canonical form to right-canonical form." << std::endl;
+         return 1;
+      }
+
+      std::cout.precision(getenv_or_default("MP_PRECISION", 14));
+      std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
+
+      if (Verbose > 0)
+         std::cout << "Loading wavefunction..." << std::endl;
+
+      pvalue_ptr<MPWavefunction> PsiPtr;
+      if (InputFile == OutputFile)
+         PsiPtr = pheap::OpenPersistent(InputFile.c_str(), mp_pheap::CacheSize());
+      else
+      {
+         pheap::Initialize(OutputFile, 1, mp_pheap::PageSize(), mp_pheap::CacheSize(), false, Force);
+         PsiPtr = pheap::ImportHeap(InputFile);
+      }
+
+      InfiniteWavefunctionLeft PsiLeft = PsiPtr->get<InfiniteWavefunctionLeft>();
+
+      if (Verbose > 0)
+         std::cout << "Right-canonicalizing wavefunction..." << std::endl;
+
+      MatrixOperator U;
+      RealDiagonalOperator D;
+      LinearWavefunction PsiLinear;
+      std::tie(U, D, PsiLinear) = get_right_canonical(PsiLeft);
+
+      InfiniteWavefunctionRight PsiRight = InfiniteWavefunctionRight(U*D, PsiLinear, PsiLeft.qshift());
+
+      if (Verbose > 0)
+         std::cout << "Saving wavefunction..." << std::endl;
+
+      PsiPtr.mutate()->Wavefunction() = PsiRight;
+      PsiPtr.mutate()->AppendHistoryCommand(EscapeCommandline(argc, argv));
+      PsiPtr.mutate()->SetDefaultAttributes();
+
+      if (Verbose > 0)
+         std::cout << "Finished." << std::endl;
+
+      pheap::ShutdownPersistent(PsiPtr);
+   }
+   catch (prog_opt::error& e)
+   {
+      std::cerr << "Exception while processing command line options: " << e.what() << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (pheap::PHeapCannotCreateFile& e)
+   {
+      std::cerr << "Exception: " << e.what() << std::endl;
+   }
+   catch (std::exception& e)
+   {
+      std::cerr << "Exception: " << e.what() << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (...)
+   {
+      std::cerr << "Unknown exception!" << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+}


### PR DESCRIPTION
Add a tool to transform a wavefunction from left-canonical to right-canonical form. Required for #3.