### PR TITLE
Fix SolveHamiltonianMPO for nontrivial qshift

### DIFF
--- a/mp-algorithms/triangular_mpo_solver_simple.cpp
+++ b/mp-algorithms/triangular_mpo_solver_simple.cpp
@@ -302,7 +302,7 @@ SolveHamiltonianMPO_Left(StateComponent& E, InfiniteWavefunctionLeft const& Psi,
    LinearWavefunction PsiLinear;
    RealDiagonalOperator Lambda;
    std::tie(PsiLinear, Lambda) = get_left_canonical(Psi);
-   MatrixOperator Rho = Lambda*Lambda;
+   MatrixOperator Rho = delta_shift(Lambda*Lambda, Psi.qshift());
    return SolveHamiltonianMPO_Left(E, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
 }
 
@@ -360,6 +360,6 @@ SolveHamiltonianMPO_Right(StateComponent& F, InfiniteWavefunctionRight const& Ps
    LinearWavefunction PsiLinear;
    RealDiagonalOperator Lambda;
    std::tie(Lambda, PsiLinear) = get_right_canonical(Psi);
-   MatrixOperator Rho = Lambda*Lambda;
+   MatrixOperator Rho = delta_shift(Lambda*Lambda, adjoint(Psi.qshift()));
    return SolveHamiltonianMPO_Right(F, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
 }


### PR DESCRIPTION
The versions of SolveHamiltonianMPO_Left/Right which take an InfiniteWavefunctionLeft/Right don't work for Hamiltonians with a nontrivial qshift. This is fixed by delta_shifting the Rho matrices.

I don't think these versions of these functions are used anywhere in the main branch, but they are used in the ibc-tdvp branch. It would probably be good to have the correct versions on the main branch anyway, in case they need to be used elsewhere.