### PR TITLE
arpack_wrapper: Sort eigenvalues depending on the value of 'which'

### DIFF
--- a/linearalgebra/arpack_wrapper.cc
+++ b/linearalgebra/arpack_wrapper.cc
@@ -42,6 +42,22 @@ inline std::string ToStr(WhichEigenvalues w)
    return "";
 }
 
+inline bool Compare(WhichEigenvalues w, std::complex<double> a, std::complex<double> b)
+{
+   switch (w)
+   {
+      case WhichEigenvalues::LargestMagnitude : return std::abs(a) > std::abs(b);
+      case WhichEigenvalues::SmallestMagnitude : return std::abs(a) < std::abs(b);
+      case WhichEigenvalues::LargestReal : return std::real(a) > std::real(b);
+      case WhichEigenvalues::SmallestReal : return std::real(a) < std::real(b);
+      case WhichEigenvalues::LargestImag : return std::imag(a) > std::imag(b);
+      case WhichEigenvalues::SmallestImag : return std::imag(a) < std::imag(b);
+      case WhichEigenvalues::LargestAlgebraic : return std::real(a) > std::real(b);
+      case WhichEigenvalues::SmallestAlgebraic : return std::real(a) < std::real(b);
+      case WhichEigenvalues::BothEnds : return false; // Do not sort.
+   }
+   return false;
+}
 
 template <typename MultFunc>
 Vector<std::complex<double>>
@@ -211,7 +227,7 @@ DiagonalizeARPACK(MultFunc Mult, int n, int NumEigen, WhichEigenvalues which, do
       {
          for (unsigned j = i+1; j < Result.size(); ++j)
          {
-            if (norm_frob(Result[j]) > norm_frob(Result[i]))
+            if (Compare(which, Result[j], Result[i]))
             {
                std::swap(Result[i], Result[j]);
                if (OutputVectors)


### PR DESCRIPTION
Issues:
- I'm not sure what to do for `BothEnds`.
- Nothing on the main branch will be affected by this, but some tools on the ibc-tdvp branch assume that the eigenvalues are in the reverse order (`mp-excitation-ansatz`) or need to be fixed anyway (`mp-ibc-join` only requests one eigenvector, but this probably won't work correctly for small matrices, since this will explictly diagonalise the matrix and return the largest, not the smallest one).