### PR TITLE
Handle EAWavefunctions in mp-reorder-symmetry and mp-wigner-eckart

### DIFF
--- a/mp/mp-reorder-symmetry.cpp
+++ b/mp/mp-reorder-symmetry.cpp
@@ -107,6 +107,20 @@ IBCWavefunction ReorderSymmetry(IBCWavefunction const& Psi, SymmetryList const& 
                           Psi.WindowRightSites);
 }
 
+EAWavefunction ReorderSymmetry(EAWavefunction const& Psi, SymmetryList const& NewSL)
+{
+   std::vector<WavefunctionSectionLeft> WindowVec = Psi.WindowVec;
+
+   for (auto& Window : WindowVec)
+      Window = ReorderSymmetry(Window, NewSL);
+
+   return EAWavefunction(ReorderSymmetry(Psi.Left, NewSL),
+                         WindowVec,
+                         ReorderSymmetry(Psi.Right, NewSL),
+                         Psi.ExpIK,
+                         Psi.GSOverlap);
+}
+
 FiniteWavefunctionLeft ReorderSymmetry(FiniteWavefunctionLeft const& Psi, SymmetryList const& NewSL)
 {
    FiniteWavefunctionLeft Result;

--- a/mp/mp-wigner-eckart.cpp
+++ b/mp/mp-wigner-eckart.cpp
@@ -161,6 +161,21 @@ wigner_project(IBCWavefunction const& Psi, SymmetryList const& FinalSL)
                           Psi.WindowRightSites);
 }
 
+EAWavefunction
+wigner_project(EAWavefunction const& Psi, SymmetryList const& FinalSL)
+{
+   std::vector<WavefunctionSectionLeft> WindowVec = Psi.WindowVec;
+
+   for (auto& Window : WindowVec)
+      Window = wigner_project(Window, FinalSL);
+
+   return EAWavefunction(wigner_project(Psi.Left, FinalSL),
+                         WindowVec,
+                         wigner_project(Psi.Right, FinalSL),
+                         Psi.ExpIK,
+                         Psi.GSOverlap);
+}
+
 FiniteWavefunctionLeft
 wigner_project(FiniteWavefunctionLeft const& Psi, SymmetryList const& FinalSL)
 {


### PR DESCRIPTION
This is required for these tools to compile on the ibc-tdvp branch.

These changes should work, but I haven't tested them. (`mp-wigner-eckart` won't work anyway, since it isn't implemented for `WavefunctionSectionLeft` at the moment.)