### PR TITLE
Allow streaming of the boundaries for the IBC and EA tools

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -223,10 +223,11 @@ tools = mp-idmrg-s3e mp-ioverlap \
         mp-idivide mp-ies mp-irepeat mp-norm mp-allcorrelation \
         mp-irotate mp-icorrelation mp-fluctuation mp-itebd mp-coarsegrain mp-finegrain mp-dmrg mp-random \
         mp-expectation mp-overlap mp-scale mp-matrix mp-tebd mp-apply mp-normalize \
-        mp-tdvp mp-itdvp mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize
+        mp-tdvp mp-itdvp mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize \
+        mp-ibc-create mp-ibc-join mp-ibc-tdvp mp-ibc-apply mp-ibc-overlap mp-ibc-correlation \
+        mp-excitation-ansatz mp-ibc-wavepacket mp-ibc-splice
 
-experimental-tools = mp-iprint mp-iproject mp-idmrg mp-iupdate mp-ibc-create mp-aux-project mp-ibc-dmrg mp-ibc-join \
-                     mp-ibc-tdvp mp-ibc-apply mp-ibc-overlap mp-ibc-correlation mp-excitation-ansatz mp-ibc-wavepacket mp-ibc-splice
+experimental-tools = mp-iprint mp-iproject mp-idmrg mp-iupdate mp-aux-project mp-ibc-dmrg
 
 
 benchmarks = benchtripleprod

--- a/mp-algorithms/excitation-ansatz.cpp
+++ b/mp-algorithms/excitation-ansatz.cpp
@@ -33,10 +33,10 @@ double const TraceTol = 1e-8;
 // if the overlap - 1 is greater than this value.
 double const OverlapTol = 1e-8;
 
-HEff::HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionLeft const& PsiRight_,
+HEff::HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionRight const& PsiRight_,
            BasicTriangularMPO const& HamMPO_, QuantumNumbers::QuantumNumber const& Q_,
            EASettings const& Settings_)
-   : PsiLeft(PsiLeft_), HamMPO(HamMPO_), Q(Q_),
+   : PsiLeft(PsiLeft_), PsiRight(PsiRight_), HamMPO(HamMPO_), Q(Q_),
      StringOp(Settings_.StringOp), GMRESTol(Settings_.GMRESTol),
      Alpha(Settings_.Alpha), Verbose(Settings_.Verbose)
 {
@@ -45,14 +45,6 @@ HEff::HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionLeft co
 
    this->SetK(Settings_.k);
    this->SetKY(Settings_.ky);
-
-   // Get PsiRight in right canonical form.
-   MatrixOperator U;
-   RealDiagonalOperator D;
-   LinearWavefunction PsiLinear;
-   std::tie(U, D, PsiLinear) = get_right_canonical(PsiRight_);
-
-   PsiRight = InfiniteWavefunctionRight(U*D, PsiLinear, PsiRight_.qshift());
 
    // Get PsiLeft and PsiRight as LinearWavefunctions.
    std::tie(PsiLinearLeft, std::ignore) = get_left_canonical(PsiLeft);
@@ -142,6 +134,9 @@ HEff::HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionLeft co
    // boundary bases (even if they come from the same state, since we
    // transformed PsiRight to right canonical form), we must calculate the
    // right canonical form of PsiLeft in such a way to preserve this boundary.
+   MatrixOperator U;
+   RealDiagonalOperator D;
+   LinearWavefunction PsiLinear;
    std::tie(U, D, PsiLinear) = get_right_canonical(PsiLeft);
    PsiLinear.set_front(prod(U, PsiLinear.get_front()));
 

--- a/mp-algorithms/excitation-ansatz.h
+++ b/mp-algorithms/excitation-ansatz.h
@@ -49,7 +49,7 @@ struct HEff
 {
    HEff() {}
 
-   HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionLeft const& PsiRight_,
+   HEff(InfiniteWavefunctionLeft const& PsiLeft_, InfiniteWavefunctionRight const& PsiRight_,
         BasicTriangularMPO const& HamMPO_, QuantumNumbers::QuantumNumber const& Q_,
         EASettings const& Settings_);
 

--- a/mp/mp-excitation-ansatz.cpp
+++ b/mp/mp-excitation-ansatz.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
 
       if (Streaming && NoStreaming)
       {
-         std::cerr << "fatal: cannot use --streaming and --no-streaming simultaneously!" << std::endl;
+         std::cerr << "fatal: Cannot use --streaming and --no-streaming simultaneously!" << std::endl;
          return 1;
       }
       else if (!Streaming && !NoStreaming)

--- a/mp/mp-ibc-apply.cpp
+++ b/mp/mp-ibc-apply.cpp
@@ -299,6 +299,14 @@ int main(int argc, char** argv)
                                (Psi.WindowLeftSites + SitesLeft) % PsiLeft.size(),
                                (Psi.WindowRightSites + SitesRight) % PsiRight.size());
 
+      // Stream the boundaries, if the input file does.
+      // UNLESS we modify the left boundary.
+      if (!Psi.WavefunctionLeftFile.empty() && vm.count("left") == 0)
+         PsiNew.WavefunctionLeftFile = Psi.WavefunctionLeftFile;
+
+      if (!Psi.WavefunctionRightFile.empty())
+         PsiNew.WavefunctionRightFile = Psi.WavefunctionRightFile;
+
       PsiPtr.mutate()->Wavefunction() = PsiNew;
 
       PsiPtr.mutate()->AppendHistoryCommand(EscapeCommandline(argc, argv));

--- a/mp/mp-ibc-join.cpp
+++ b/mp/mp-ibc-join.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv)
 
       if (Streaming && NoStreaming)
       {
-         std::cerr << "fatal: cannot use --streaming and --no-streaming simultaneously!" << std::endl;
+         std::cerr << "fatal: Cannot use --streaming and --no-streaming simultaneously!" << std::endl;
          return 1;
       }
       else if (!Streaming && !NoStreaming)

--- a/mp/mp-ibc-join.cpp
+++ b/mp/mp-ibc-join.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
       bool Force = false;
       double GMRESTol = 1E-13;    // tolerance for GMRES for the initial H matrix elements.
       double Tol = 1E-15;
+      bool Streaming = false;
       int NumEigen = 1;
 
       prog_opt::options_description desc("Allowed options", terminal::columns());
@@ -83,6 +84,7 @@ int main(int argc, char** argv)
          ("tol", prog_opt::value(&Tol), FormatDefault("Tolerance of the eigensolver", Tol).c_str())
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("Error tolerance for the GMRES algorithm", GMRESTol).c_str())
+         ("streaming", prog_opt::bool_switch(&Streaming), "Store the left and right strips by reference to the input files")
          ("verbose,v",  prog_opt_ext::accum_value(&Verbose),
           "extra debug output [can be used multiple times]")
          ;
@@ -139,7 +141,7 @@ int main(int argc, char** argv)
       }
       else
       {
-         std::cerr << "FATAL: right_psi must be an InfiniteWavefunctionLeft or InfiniteWavefunctionRight." << std::endl;
+         std::cerr << "fatal: right_psi must be an InfiniteWavefunctionLeft or InfiniteWavefunctionRight." << std::endl;
          return 1;
       }
 
@@ -208,6 +210,18 @@ int main(int argc, char** argv)
       Window = WavefunctionSectionLeft(C);
 
       IBCWavefunction ResultPsi(PsiLeft, Window, PsiRight, 0);
+
+      if (Streaming)
+      {
+         if (!InPsiRight->is<InfiniteWavefunctionRight>())
+         {
+            std::cerr << "fatal: right_psi must be an InfiniteWavefunctionRight is streaming is enabled." << std::endl;
+            return 1;
+         }
+
+         ResultPsi.WavefunctionLeftFile = InputFileLeft;
+         ResultPsi.WavefunctionRightFile = InputFileRight;
+      }
 
       MPWavefunction Result(ResultPsi);
 

--- a/mp/mp-ibc-join.cpp
+++ b/mp/mp-ibc-join.cpp
@@ -117,20 +117,31 @@ int main(int argc, char** argv)
 
       InfiniteWavefunctionLeft PsiLeft = InPsiLeft->get<InfiniteWavefunctionLeft>();
 
-      // There are some situations where the first method does not work
-      // properly, so temporarily use the second method as a workaround.
+      InfiniteWavefunctionRight PsiRight;
+      if (InPsiRight->is<InfiniteWavefunctionRight>())
+         PsiRight = InPsiRight->get<InfiniteWavefunctionRight>();
+      else if (InPsiRight->is<InfiniteWavefunctionLeft>())
+      {
+         // There are some situations where the first method does not work
+         // properly, so temporarily use the second method as a workaround.
 #if 0
-      InfiniteWavefunctionRight PsiRight = InPsiRight->get<InfiniteWavefunctionLeft>();
+         InfiniteWavefunctionRight PsiRight = InPsiRight->get<InfiniteWavefunctionLeft>();
 #else
-      InfiniteWavefunctionLeft PsiRightLeft = InPsiRight->get<InfiniteWavefunctionLeft>();
+         InfiniteWavefunctionLeft PsiRightLeft = InPsiRight->get<InfiniteWavefunctionLeft>();
 
-      MatrixOperator U;
-      RealDiagonalOperator D;
-      LinearWavefunction PsiRightLinear;
-      std::tie(U, D, PsiRightLinear) = get_right_canonical(PsiRightLeft);
+         MatrixOperator U;
+         RealDiagonalOperator D;
+         LinearWavefunction PsiRightLinear;
+         std::tie(U, D, PsiRightLinear) = get_right_canonical(PsiRightLeft);
 
-      InfiniteWavefunctionRight PsiRight(U*D, PsiRightLinear, PsiRightLeft.qshift());
+         PsiRight = InfiniteWavefunctionRight(U*D, PsiRightLinear, PsiRightLeft.qshift());
 #endif
+      }
+      else
+      {
+         std::cerr << "FATAL: right_psi must be an InfiniteWavefunctionLeft or InfiniteWavefunctionRight." << std::endl;
+         return 1;
+      }
 
       // If the bases of the two boundary unit cells have only one quantum
       // number sector, manually ensure that they match.

--- a/mp/mp-ibc-splice.cpp
+++ b/mp/mp-ibc-splice.cpp
@@ -302,6 +302,13 @@ int main(int argc, char** argv)
 
       IBCWavefunction PsiOut(PsiLeft.Left, PsiWindow, PsiRight.Right, PsiLeft.window_offset(), PsiLeft.WindowLeftSites, PsiRight.WindowRightSites);
 
+      // Stream the boundaries, if the input files do.
+      if (!PsiLeft.WavefunctionLeftFile.empty())
+         PsiOut.WavefunctionLeftFile = PsiLeft.WavefunctionLeftFile;
+
+      if (!PsiRight.WavefunctionRightFile.empty())
+         PsiOut.WavefunctionRightFile = PsiRight.WavefunctionRightFile;
+
       MPWavefunction Wavefunction;
       Wavefunction.Wavefunction() = std::move(PsiOut);
       Wavefunction.AppendHistoryCommand(EscapeCommandline(argc, argv));

--- a/mp/mp-ibc-splice.cpp
+++ b/mp/mp-ibc-splice.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 
       if (std::abs(std::abs(Overlap) - 1.0) > OverlapTol)
       {
-         std::cerr << "FATAL: The overlap of two middle boundaries is significantly less than 1." << std::endl;
+         std::cerr << "fatal: The overlap of two middle boundaries is significantly less than 1." << std::endl;
          return 1;
       }
 

--- a/mp/mp-ibc-tdvp.cpp
+++ b/mp/mp-ibc-tdvp.cpp
@@ -263,10 +263,19 @@ int main(int argc, char** argv)
          // Save the wavefunction.
          if ((tstep % SaveEvery) == 0 || tstep == N)
          {
-            MPWavefunction Wavefunction;
+            IBCWavefunction PsiSave = tdvp.Wavefunction();
+
+            // Stream the boundaries, if the input file does.
+            if (!Psi.WavefunctionLeftFile.empty())
+               PsiSave.WavefunctionLeftFile = Psi.WavefunctionLeftFile;
+
+            if (!Psi.WavefunctionRightFile.empty())
+               PsiSave.WavefunctionRightFile = Psi.WavefunctionRightFile;
+
             std::string TimeStr = formatting::format_digits(std::real(InitialTime + double(tstep)*Timestep), OutputDigits);
             std::string BetaStr = formatting::format_digits(-std::imag(InitialTime + double(tstep)*Timestep), OutputDigits);
-            IBCWavefunction PsiSave = tdvp.Wavefunction();
+
+            MPWavefunction Wavefunction;
             Wavefunction.Wavefunction() = std::move(PsiSave);
             Wavefunction.AppendHistoryCommand(EscapeCommandline(argc, argv));
             Wavefunction.SetDefaultAttributes();

--- a/mp/mp-ibc-wavepacket.cpp
+++ b/mp/mp-ibc-wavepacket.cpp
@@ -417,7 +417,7 @@ int main(int argc, char** argv)
             std::cerr << "WARNING: 2/KYStep=" << 2.0/KYStep << " is noninteger! Trying NY=" << NY << std::endl;
          if (NY < 4)
          {
-            std::cerr << "FATAL: NY=" << NY << " is less than 4: cannot localize wavepacket along the y-axis." << std::endl;
+            std::cerr << "fatal: NY=" << NY << " is less than 4: cannot localize wavepacket along the y-axis!" << std::endl;
             return 1;
          }
       }
@@ -467,7 +467,7 @@ int main(int argc, char** argv)
 
       if (!Finished)
       {
-         std::cerr << "FATAL: Cannot localize wavepacket." << std::endl;
+         std::cerr << "fatal: Cannot localize wavepacket." << std::endl;
          return 1;
       }
 

--- a/mp/mp-ibc-wavepacket.cpp
+++ b/mp/mp-ibc-wavepacket.cpp
@@ -232,6 +232,8 @@ int main(int argc, char** argv)
       double KYCenter = 0.0;
       int InputDigits = -1;
       double Tol = 1e-5;
+      std::string LeftBoundaryFilename;
+      std::string RightBoundaryFilename;
 
       prog_opt::options_description desc("Allowed options", terminal::columns());
       desc.add_options()
@@ -306,6 +308,14 @@ int main(int argc, char** argv)
 
          pvalue_ptr<MPWavefunction> InPsi = pheap::ImportHeap(InputFilename);
          EAWavefunction Psi = InPsi->get<EAWavefunction>();
+
+         // If the input streams the boundaries, then we save them so we can
+         // stream them in the output as well.
+         if (!Psi.WavefunctionLeftFile.empty())
+            LeftBoundaryFilename = Psi.WavefunctionLeftFile;
+
+         if (!Psi.WavefunctionRightFile.empty())
+            RightBoundaryFilename = Psi.WavefunctionRightFile;
 
          PsiLeft = Psi.Left;
          PsiRight = Psi.Right;
@@ -543,6 +553,13 @@ int main(int argc, char** argv)
          std::cout << "Saving wavefunction..." << std::endl;
 
       IBCWavefunction PsiOut(PsiLeft, PsiWindow, PsiRight, -Lambda*UCSize);
+
+      // Stream the boundaries, if the input files do.
+      if (!LeftBoundaryFilename.empty())
+         PsiOut.WavefunctionLeftFile = LeftBoundaryFilename;
+
+      if (!RightBoundaryFilename.empty())
+         PsiOut.WavefunctionRightFile = RightBoundaryFilename;
 
       MPWavefunction Wavefunction;
       Wavefunction.Wavefunction() = std::move(PsiOut);

--- a/wavefunction/ea.h
+++ b/wavefunction/ea.h
@@ -69,6 +69,11 @@ class EAWavefunction
       // Assume that each window has the same size.
       int window_size() const { return WindowVec.front().size(); }
 
+      // Return the filename of the left/right windows.  If this is empty then the
+      // wavefunctions are stored directly in this object
+      std::string LeftWindowFile() const { return WavefunctionLeftFile; }
+      std::string RightWindowFile() const { return WavefunctionRightFile; }
+
       void SetDefaultAttributes(AttributeList& A) const;
 
       static std::string const Type;
@@ -80,6 +85,10 @@ class EAWavefunction
 
       // private:
 
+      // We can optionally save the left and right semi-infinite wavefunctions on disc by reference to a file.
+      // If these strings are non-empty then the Left and Right components are not saved when this wavefunction
+      // is streamed to disc.
+      std::string WavefunctionLeftFile, WavefunctionRightFile;
       InfiniteWavefunctionLeft Left;
       std::vector<WavefunctionSectionLeft> WindowVec;
       InfiniteWavefunctionRight Right;


### PR DESCRIPTION
Storing the left and right boundary strips of an IBC wavefuntion as a reference to a file appears to work properly, in that I can read such files using `mp-expectation`.

Now each file that can output an IBC wavefunction should be updated to allow streaming. But there are some problems/questions that I have:
- Should saving by reference to a file be the default behaviour or not? At the moment, `mp-ibc-join` saves the boundaries in the IBC file by default, and allows saving by reference if the `--streaming` option is enabled.
  - `mp-ibc-join` works if the right boundary is in left- or right-canonical form for the current default behaviour, but if `--streaming` is enabled, then it prints an error message and aborts if it isn't in right-canonical form.
- For a tool which can read and output an IBC, I think the best behaviour would be to match the input files, so that if the input files are streaming, then the output will be as well, but if the input files are not streaming, then the output files will not be.
  - Would there any point in having an option which would save the boundaries into the output files if they are saved as references in the inputs?
- At the moment, it is possible for an IBCWavefunction file to have only one of the boundaries saved as a reference to a file, with the other one saved in the file. What should be the output behaviour for such input files? Or should such files be considered invalid?
- What should I do if there are multiple input IBCs, and some of them store the boundaries by reference, and some do not? My guess would be to store the boundaries inside the output file.
- At the moment, all tools which reads and outputs an IBC only changes the window, except for `mp-ibc-apply`, where there is an option to apply a string operator to the left boundary. Running `mp-iapply` on the right boundary would have the correct behaviour. I think the best solution would be to require a filename for a new right file to be supplied as an option.
  - Actually, some other tools like `mp-reflect`, `mp-reorder-symmetry` and `mp-wigner-eckart` will also change the boundaries.