### PR TITLE
Move read-only objects of IBCWavefunction to private

### DIFF
--- a/mp/mp-info.cpp
+++ b/mp/mp-info.cpp
@@ -65,7 +65,7 @@ void ShowBasicInfo(IBCWavefunction const& Psi, std::ostream& out)
    out << "Infinite Boundary Condition wavefunction in the left/left/right orthogonal basis.\n";
    out << "Symmetry list = " << Psi.window().GetSymmetryList() << '\n';
 
-   std::string lw = Psi.left_filename();
+   std::string lw = Psi.get_left_filename();
    if (lw.empty())
       out << "Left semi-infinite strip is stored directly.\n";
    else
@@ -76,7 +76,7 @@ void ShowBasicInfo(IBCWavefunction const& Psi, std::ostream& out)
       out << "Quantum number per unit cell (left) = " << Psi.left().qshift() << '\n';
    }
 
-   std::string rw = Psi.right_filename();
+   std::string rw = Psi.get_right_filename();
    if (rw.empty())
       out << "Right semi-infinite strip is stored directly.\n";
    else

--- a/mp/mp-info.cpp
+++ b/mp/mp-info.cpp
@@ -63,34 +63,34 @@ void ShowBasicInfo(InfiniteWavefunctionRight const& Psi, std::ostream& out)
 void ShowBasicInfo(IBCWavefunction const& Psi, std::ostream& out)
 {
    out << "Infinite Boundary Condition wavefunction in the left/left/right orthogonal basis.\n";
-   out << "Symmetry list = " << Psi.Window.GetSymmetryList() << '\n';
+   out << "Symmetry list = " << Psi.window().GetSymmetryList() << '\n';
 
-   std::string lw = Psi.LeftWindowFile();
+   std::string lw = Psi.left_filename();
    if (lw.empty())
       out << "Left semi-infinite strip is stored directly.\n";
    else
       out << "Left semi-infinite strip is stored in the file \"" << lw << "\"\n";
-   out << "Left semi-infinite strip unit cell size = " << Psi.Left.size() << '\n';
-   if (!Psi.Left.empty())
+   out << "Left semi-infinite strip unit cell size = " << Psi.left().size() << '\n';
+   if (!Psi.left().empty())
    {
-      out << "Quantum number per unit cell (left) = " << Psi.Left.qshift() << '\n';
+      out << "Quantum number per unit cell (left) = " << Psi.left().qshift() << '\n';
    }
 
-   std::string rw = Psi.RightWindowFile();
+   std::string rw = Psi.right_filename();
    if (rw.empty())
       out << "Right semi-infinite strip is stored directly.\n";
    else
       out << "Right semi-infinite strip is stored in the file \"" << rw << "\"\n";
-   out << "Right semi-infinite strip unit cell size = " << Psi.Right.size() << '\n';
-   if (!Psi.Right.empty())
+   out << "Right semi-infinite strip unit cell size = " << Psi.right().size() << '\n';
+   if (!Psi.right().empty())
    {
-      out << "Quantum number per unit cell (right) = " << Psi.Right.qshift() << '\n';
+      out << "Quantum number per unit cell (right) = " << Psi.right().qshift() << '\n';
    }
 
-   out << "Window size = " << Psi.Window.size() << '\n';
+   out << "Window size = " << Psi.window_size() << '\n';
    out << "Offset of first site of the window = " << Psi.window_offset() << '\n';
 
-   out << "Number of states (left edge of window) = " << Psi.Window.Basis1().total_dimension() << '\n';
+   out << "Number of states (left edge of window) = " << Psi.window().Basis1().total_dimension() << '\n';
 }
 
 void ShowBasicInfo(FiniteWavefunctionLeft const& Psi, std::ostream& out)
@@ -295,22 +295,22 @@ ShowWavefunction::operator()(IBCWavefunction const& Psi) const
    }
 
    if (ShowStates)
-      ShowStateInfo(Psi.Window, std::cout);
+      ShowStateInfo(Psi.window(), std::cout);
 
    if (ShowBasis)
-      ShowBasisInfo(Psi.Window, std::cout);
+      ShowBasisInfo(Psi.window(), std::cout);
 
    if (ShowEntropy)
-      ShowEntropyInfo(Psi.Window, std::cout);
+      ShowEntropyInfo(Psi.window(), std::cout);
 
    if (ShowDensity)
-      ShowDM(Psi.Window, std::cout);
+      ShowDM(Psi.window(), std::cout);
 
    if (ShowCasimir)
-      ShowCasimirInfo(Psi.Window, std::cout);
+      ShowCasimirInfo(Psi.window(), std::cout);
 
    if (ShowLocalBasis)
-      ShowLocalBasisInfo(Psi.Window, std::cout);
+      ShowLocalBasisInfo(Psi.window(), std::cout);
 }
 
 void

--- a/mp/mp-reorder-symmetry.cpp
+++ b/mp/mp-reorder-symmetry.cpp
@@ -99,12 +99,12 @@ WavefunctionSectionLeft ReorderSymmetry(WavefunctionSectionLeft const& Psi, Symm
 
 IBCWavefunction ReorderSymmetry(IBCWavefunction const& Psi, SymmetryList const& NewSL)
 {
-   return IBCWavefunction(ReorderSymmetry(Psi.Left, NewSL),
-                          ReorderSymmetry(Psi.Window, NewSL),
-                          ReorderSymmetry(Psi.Right, NewSL),
+   return IBCWavefunction(ReorderSymmetry(Psi.left(), NewSL),
+                          ReorderSymmetry(Psi.window(), NewSL),
+                          ReorderSymmetry(Psi.right(), NewSL),
                           Psi.window_offset(),
-                          Psi.WindowLeftSites,
-                          Psi.WindowRightSites);
+                          Psi.window_left_sites(),
+                          Psi.window_right_sites());
 }
 
 FiniteWavefunctionLeft ReorderSymmetry(FiniteWavefunctionLeft const& Psi, SymmetryList const& NewSL)

--- a/mp/mp-wigner-eckart.cpp
+++ b/mp/mp-wigner-eckart.cpp
@@ -153,12 +153,12 @@ wigner_project(WavefunctionSectionLeft const& Psi, SymmetryList const& FinalSL)
 IBCWavefunction
 wigner_project(IBCWavefunction const& Psi, SymmetryList const& FinalSL)
 {
-   return IBCWavefunction(wigner_project(Psi.Left, FinalSL),
-                          wigner_project(Psi.Window, FinalSL),
-                          wigner_project(Psi.Right, FinalSL),
+   return IBCWavefunction(wigner_project(Psi.left(), FinalSL),
+                          wigner_project(Psi.window(), FinalSL),
+                          wigner_project(Psi.right(), FinalSL),
                           Psi.window_offset(),
-                          Psi.WindowLeftSites,
-                          Psi.WindowRightSites);
+                          Psi.window_left_sites(),
+                          Psi.window_right_sites());
 }
 
 FiniteWavefunctionLeft

--- a/wavefunction/ibc.cpp
+++ b/wavefunction/ibc.cpp
@@ -341,6 +341,6 @@ IBCWavefunction::SetDefaultAttributes(AttributeList& A) const
    A["WindowOffset"] = this->window_offset();
    A["LeftUnitCellSize"] = Left.size();
    A["RightUnitCellSize"] = Left.size();
-   A["LeftFilename"] = this->left_filename();
-   A["RightFilename"] = this->right_filename();
+   A["LeftFilename"] = this->get_left_filename();
+   A["RightFilename"] = this->get_right_filename();
 }

--- a/wavefunction/ibc.cpp
+++ b/wavefunction/ibc.cpp
@@ -202,8 +202,10 @@ IBCWavefunction::IBCWavefunction()
 IBCWavefunction::IBCWavefunction(InfiniteWavefunctionLeft const& Left_,
                                  WavefunctionSectionLeft const& Window_,
                                  InfiniteWavefunctionRight const& Right_,
-                                 int Offset)
-   : WindowLeftSites(0), WindowRightSites(0), WindowOffset(Offset),
+                                 int Offset,
+                                 int WindowLeft,
+                                 int WindowRight)
+   : WindowLeftSites(WindowLeft), WindowRightSites(WindowRight), WindowOffset(Offset),
      Left(Left_), Window(Window_), Right(Right_)
 {
 }
@@ -211,10 +213,13 @@ IBCWavefunction::IBCWavefunction(InfiniteWavefunctionLeft const& Left_,
 IBCWavefunction::IBCWavefunction(InfiniteWavefunctionLeft const& Left_,
                                  WavefunctionSectionLeft const& Window_,
                                  InfiniteWavefunctionRight const& Right_,
+                                 std::string LeftFilename,
+                                 std::string RightFilename,
                                  int Offset,
                                  int WindowLeft,
                                  int WindowRight)
    : WindowLeftSites(WindowLeft), WindowRightSites(WindowRight), WindowOffset(Offset),
+     WavefunctionLeftFile(LeftFilename), WavefunctionRightFile(RightFilename),
      Left(Left_), Window(Window_), Right(Right_)
 {
 }
@@ -336,6 +341,6 @@ IBCWavefunction::SetDefaultAttributes(AttributeList& A) const
    A["WindowOffset"] = this->window_offset();
    A["LeftUnitCellSize"] = Left.size();
    A["RightUnitCellSize"] = Left.size();
-   A["LeftWindowFile"] = this->LeftWindowFile();
-   A["RightWindowFile"] = this->RightWindowFile();
+   A["LeftFilename"] = this->left_filename();
+   A["RightFilename"] = this->right_filename();
 }

--- a/wavefunction/ibc.h
+++ b/wavefunction/ibc.h
@@ -114,25 +114,33 @@ class IBCWavefunction
       IBCWavefunction(InfiniteWavefunctionLeft const& Left_,
                       WavefunctionSectionLeft const& Window_,
                       InfiniteWavefunctionRight const& Right_,
-                      int Offset = 0);
+                      int Offset = 0,
+                      int WindowLeft = 0,
+                      int WindowRight = 0);
 
       IBCWavefunction(InfiniteWavefunctionLeft const& Left_,
                       WavefunctionSectionLeft const& Window_,
                       InfiniteWavefunctionRight const& Right_,
-                      int Offset,
-                      int WindowLeft,
-                      int WindowRight);
+                      std::string LeftFilename,
+                      std::string RightFilename,
+                      int Offset = 0,
+                      int WindowLeft = 0,
+                      int WindowRight = 0);
 
       SymmetryList GetSymmetryList() const { return Window.GetSymmetryList(); }
 
       int window_size() const { return Window.size(); }
 
+      int window_left_sites() const { return WindowLeftSites; }
+      int window_right_sites() const { return WindowRightSites; }
       int window_offset() const { return WindowOffset; }
 
-      // Return the filename of the left/right windows.  If this is empty then the
-      // wavefunctions are stored directly in this object
-      std::string LeftWindowFile() const { return WavefunctionLeftFile; }
-      std::string RightWindowFile() const { return WavefunctionRightFile; }
+      std::string left_filename() const { return WavefunctionLeftFile; }
+      std::string right_filename() const { return WavefunctionRightFile; }
+
+      InfiniteWavefunctionLeft const& left() const { return Left; }
+      WavefunctionSectionLeft const& window() const { return Window; }
+      InfiniteWavefunctionRight const& right() const { return Right; }
 
       void SetDefaultAttributes(AttributeList& A) const;
 
@@ -143,7 +151,7 @@ class IBCWavefunction
       void check_structure() const;
       void debug_check_structure() const;
 
-      // private:
+      private:
 
       // Number of sites of the Left unit cell that have been incorporated into
       // the Window (from 0 .. Left.size()-1)

--- a/wavefunction/ibc.h
+++ b/wavefunction/ibc.h
@@ -135,8 +135,11 @@ class IBCWavefunction
       int window_right_sites() const { return WindowRightSites; }
       int window_offset() const { return WindowOffset; }
 
-      std::string left_filename() const { return WavefunctionLeftFile; }
-      std::string right_filename() const { return WavefunctionRightFile; }
+      std::string get_left_filename() const { return WavefunctionLeftFile; }
+      std::string get_right_filename() const { return WavefunctionRightFile; }
+
+      void set_left_filename(std::string LeftFilename) { WavefunctionLeftFile = LeftFilename; }
+      void set_right_filename(std::string RightFilename) { WavefunctionRightFile = RightFilename; }
 
       InfiniteWavefunctionLeft const& left() const { return Left; }
       WavefunctionSectionLeft const& window() const { return Window; }


### PR DESCRIPTION
Since the `IBCWavefunction` class is supposed to be read-only, it would be better to put all of the data under private, and add functions to return these read-only objects. Most code using `IBCWavefunction`s should be updated to use these functions instead of trying to get the read-only objects directly, which should be simple. If there is any code trying to modify the read-only objects, it is wrong and should be fixed.

I think I fixed everything on the main branch, but once this gets pushed into ibc-tdvp, I'll have to fix everything else there.

I also renamed `Left/RightWindowFile` to `Left/RightFilename`.

Issues:

* I'm not sure what the convention should be for the cases for the class functions of `IBCWavefunction` (i.e. `lower_case_with_underscores` vs `CamelCase`). I made the functions which return the read-only objects of `IBCWavefunction` lower case with underscores, to match the existing functions (e.g. `window_offset()`), but this is not entirely consitent with other functions (e.g. `LeftU()` in `WavefunctionSectionLeft`).

* I added a new constructor which allow `Left/RightFilename` to be specfied. I also consolidated the two existing constructors into one, which shouldn't cause any problems(?): see https://github.com/ianmccul/mptoolkit-dev/pull/21#issuecomment-1311143313