### PR TITLE
Add OpenMP support for mp-tebd

### DIFF
--- a/mp/mp-tebd.cpp
+++ b/mp/mp-tebd.cpp
@@ -58,10 +58,11 @@ void DoEvenSlice(std::deque<StateComponent>& Psi,
       Lambda.push_back(Lambda.back());
    }
    int MaxStates = 0;
-   #pragma omp parallel for shared(Psi, Lambda, UEven, SInfo)
+   double DeltaLogAmplitude = 0;
+   #pragma omp parallel for reduction(+:DeltaLogAmplitude)
    for (unsigned i = 0; i < Sz-1; i += 2)
    {
-      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[i/2], LogAmplitude, UEven[i/2], SInfo);
+      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[i/2], DeltaLogAmplitude, UEven[i/2], SInfo);
       if (Verbose > 0)
       {
          std::cout << "Bond=" << (i+1)
@@ -73,6 +74,7 @@ void DoEvenSlice(std::deque<StateComponent>& Psi,
       #pragma omp critical
          MaxStates = std::max(MaxStates, Info.KeptStates());
    }
+   LogAmplitude += DeltaLogAmplitude;
    std::cout << "Even slice finished, max states=" << MaxStates << '\n';
    std::cout << std::flush;
 }
@@ -98,10 +100,11 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
    }
    Lambda.pop_front();
    int MaxStates = 0;
-   #pragma omp parallel for shared(Psi, Lambda, UOdd, SInfo)
+   double DeltaLogAmplitude = 0;
+   #pragma omp parallel for reduction(+:DeltaLogAmplitude)
    for (unsigned i = 1; i < Sz-1; i += 2)
    {
-      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[(i-1)/2], LogAmplitude, UOdd[(i-1)/2], SInfo);
+      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[(i-1)/2], DeltaLogAmplitude, UOdd[(i-1)/2], SInfo);
       if (Verbose > 0)
       {
          std::cout << "Bond=" << i
@@ -113,6 +116,7 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
       #pragma omp critical
          MaxStates = std::max(MaxStates, Info.KeptStates());
    }
+   LogAmplitude += DeltaLogAmplitude;
    std::cout << "Odd slice finished, max states=" << MaxStates << '\n';
    std::cout << std::flush;
 }

--- a/mp/mp-tebd.cpp
+++ b/mp/mp-tebd.cpp
@@ -58,6 +58,7 @@ void DoEvenSlice(std::deque<StateComponent>& Psi,
       Lambda.push_back(Lambda.back());
    }
    int MaxStates = 0;
+   #pragma omp parallel for shared(Psi, Lambda, UEven, SInfo)
    for (unsigned i = 0; i < Sz-1; i += 2)
    {
       TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[i/2], LogAmplitude, UEven[i/2], SInfo);
@@ -69,7 +70,8 @@ void DoEvenSlice(std::deque<StateComponent>& Psi,
                    << " Trunc=" << Info.TruncationError()
                    << '\n';
       }
-      MaxStates = std::max(MaxStates, Info.KeptStates());
+      #pragma omp critical
+         MaxStates = std::max(MaxStates, Info.KeptStates());
    }
    std::cout << "Even slice finished, max states=" << MaxStates << '\n';
    std::cout << std::flush;
@@ -96,6 +98,7 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
    }
    Lambda.pop_front();
    int MaxStates = 0;
+   #pragma omp parallel for shared(Psi, Lambda, UOdd, SInfo)
    for (unsigned i = 1; i < Sz-1; i += 2)
    {
       TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[(i-1)/2], LogAmplitude, UOdd[(i-1)/2], SInfo);
@@ -107,7 +110,8 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
                    << " Trunc=" << Info.TruncationError()
                    << '\n';
       }
-      MaxStates = std::max(MaxStates, Info.KeptStates());
+      #pragma omp critical
+         MaxStates = std::max(MaxStates, Info.KeptStates());
    }
    std::cout << "Odd slice finished, max states=" << MaxStates << '\n';
    std::cout << std::flush;


### PR DESCRIPTION
OpenMP is currently only used for iTEBD, so I just copied and pasted the relevant lines from the `mp-itebd` code to `mp-tebd`.

I actually want to do parallelised evolution for IBC wavefunctions, so I will probably put together a `mp-ibc-tebd`, which will probably be mostly a copy-and-paste of `mp-tebd`, since I won't include any of the IBC specific features yet, and just treat the window as a fixed-size finite MPS. (For scattering wavepackets, I don't think the boundary effects will be very significant in the timescales that we are interested in.)

@ianmccul I am unsure about one thing: should
```#pragma omp parallel for shared(Psi, Lambda, UEven, SInfo)```
be updated to include LogAmplitude (both here in `mp-tebd` and in the original `mp-itebd`)?
```#pragma omp parallel for shared(Psi, Lambda, LogAmplitude, UEven, SInfo)```