### PR TITLE
Add mp-construct

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -223,7 +223,8 @@ tools = mp-idmrg-s3e mp-ioverlap \
         mp-idivide mp-ies mp-irepeat mp-norm mp-allcorrelation \
         mp-irotate mp-icorrelation mp-itebd mp-coarsegrain mp-finegrain mp-dmrg mp-random \
         mp-expectation mp-overlap mp-scale mp-matrix mp-tebd mp-apply mp-normalize \
-				mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize mp-left-canonicalize
+				mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize mp-left-canonicalize \
+                                mp-construct
 
 experimental-tools = mp-iprint mp-iproject mp-idmrg mp-iupdate mp-ibc-create mp-aux-project mp-ibc-dmrg mp-fluctuation
 

--- a/mp/mp-construct.cpp
+++ b/mp/mp-construct.cpp
@@ -1,0 +1,270 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://physics.uq.edu.au/people/ianmcc/mptoolkit/
+//
+// mp/mp-construct.cpp
+//
+// Copyright (C) 2022 Jesse Osborne <j.osborne@uqconnect.edu.au>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Reseach publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#include "common/environment.h"
+#include "common/formatting.h"
+#include "common/prog_opt_accum.h"
+#include "common/prog_options.h"
+#include "common/terminal.h"
+#include "common/unique.h"
+#include "interface/inittemp.h"
+#include "lattice/infinitelattice.h"
+#include "linearalgebra/eigen.h"
+#include "mp/copyright.h"
+#include "wavefunction/mpwavefunction.h"
+
+namespace prog_opt = boost::program_options;
+
+int main(int argc, char** argv)
+{
+   try
+   {
+      int Verbose = 0;
+      std::string LatticeFilename;
+      std::string OutputFilename;
+      std::string States;
+      bool Infinite = false;
+      bool Finite = false;
+      bool Force = false;
+
+      prog_opt::options_description desc("Allowed options", terminal::columns());
+      desc.add_options()
+         ("help", "Show this help message")
+         ("lattice,l", prog_opt::value(&LatticeFilename), "Lattice filename [required]")
+         ("output,o", prog_opt::value(&OutputFilename), "Output filename [required]")
+         ("force,f", prog_opt::bool_switch(&Force), "Force overwriting output file")
+         ("infinite", prog_opt::bool_switch(&Infinite), "Create an infinite wavefunction [default]")
+         ("finite", prog_opt::bool_switch(&Finite), "Create a finite wavefunction")
+         ("verbose,v",  prog_opt_ext::accum_value(&Verbose), "Increase verbosity (can be used more than once)")
+         ;
+
+      prog_opt::options_description hidden("Hidden options");
+      hidden.add_options()
+         ("states", prog_opt::value(&States), "states")
+         ;
+
+      prog_opt::positional_options_description p;
+      p.add("states", 1);
+
+      prog_opt::options_description opt;
+      opt.add(desc).add(hidden);
+
+      prog_opt::variables_map vm;
+      prog_opt::store(prog_opt::command_line_parser(argc, argv).
+                      options(opt).positional(p).run(), vm);
+      prog_opt::notify(vm);
+
+      if (vm.count("help") || vm.count("lattice") == 0 || vm.count("output") == 0 || vm.count("states") == 0)
+      {
+         print_copyright(std::cerr, "tools", basename(argv[0]));
+         std::cerr << "usage: " << basename(argv[0]) << " [options] <states>" << std::endl;
+         std::cerr << desc << std::endl;
+         return 1;
+      }
+
+      if (Infinite && Finite)
+      {
+         std::cerr << "fatal: Cannot use --infinite and --finite simultaneously!" << std::endl;
+         return 1;
+      }
+      else if (!Infinite && !Finite)
+         Infinite = true; // This is the current default behavior.
+
+      std::cout.precision(getenv_or_default("MP_PRECISION", 14));
+      std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
+
+      pheap::Initialize(OutputFilename, 1, mp_pheap::PageSize(), mp_pheap::CacheSize(), false, Force);
+
+      pvalue_ptr<InfiniteLattice> Lattice = pheap::ImportHeap(LatticeFilename);
+      SymmetryList SL = Lattice->GetSymmetryList();
+
+      LinearWavefunction Psi;
+
+      if (States.find(':') != -1 && States.find_first_of("()") != -1)
+      {
+         std::cerr << "fatal: Invalid string: you cannot use both of the \":\" and \"()\" separators." << std::endl;
+         return 1;
+      }
+
+      QuantumNumber QLast(SL);
+      QuantumNumber QPrev = QLast;
+
+      auto Site = Lattice->GetUnitCell().end();
+
+      if (States.find_first_of("()") != -1)
+      {
+         // Parse strings with separators (), which specify the bond quantum numbers explicitly.
+         // Read the quantum number of the last bond.
+         int End = States.find_last_not_of(") ");
+         int Start = States.find_last_of("( ", End);
+         std::string Label = States.substr(Start+1, End-Start);
+
+         QLast = QuantumNumber(SL, Label);
+         QPrev = QLast;
+
+         VectorBasis BasisPrev(SL);
+         BasisPrev.push_back(QPrev, 1);
+
+         // Iterate backwards from the end.
+         while (States.find_last_not_of("( ", Start) != -1)
+         {
+            --Site;
+
+            // Read the local state label.
+            End = States.find_last_not_of("( ", Start);
+            Start = States.find_last_of(") ", End);
+            Label = States.substr(Start+1, End-Start);
+
+            SiteBasis LocalBasis = Site->Basis2();
+            int Index = LocalBasis.Lookup(Label);
+
+            // Read the bond quantum number label.
+            End = States.find_last_not_of(") ", Start);
+            Start = States.find_last_of("( ", End);
+            Label = States.substr(Start+1, End-Start);
+
+            QuantumNumber Q(SL, Label);
+
+            VectorBasis Basis(SL);
+            Basis.push_back(Q, 1);
+
+            // Form the local A-matrix.
+            StateComponent A(LocalBasis, Basis, BasisPrev);
+            A[Index](0,0) = LinearAlgebra::Matrix<double>(1,1,1.0);
+            Psi.push_front(A);
+
+            QPrev = Q;
+            BasisPrev = Basis;
+            if (Site == Lattice->GetUnitCell().begin())
+               Site = Lattice->GetUnitCell().end();
+         }
+      }
+      else
+      {
+         // Parse strings with separator : (or just whitespaces.)
+         int End = 0;
+         int Start = -1;
+
+         VectorBasis BasisPrev(SL);
+         BasisPrev.push_back(QPrev, 1);
+
+         // Iterate backwards from the end.
+         do
+         {
+            --Site;
+
+            // Read the local state label.
+            End = States.find_last_not_of(": ", Start);
+            Start = States.find_last_of(": ", End);
+            std::string Label = States.substr(Start+1, End-Start);
+
+            SiteBasis LocalBasis = Site->Basis2();
+            int Index = LocalBasis.Lookup(Label);
+
+            // The next quantum number is found using the previous one and the local state.
+            QuantumNumber Q = delta_shift(QPrev, LocalBasis.qn(Index));
+
+            VectorBasis Basis(SL);
+            Basis.push_back(Q, 1);
+
+            // Form the local A-matrix.
+            StateComponent A(LocalBasis, Basis, BasisPrev);
+            A[Index](0,0) = LinearAlgebra::Matrix<double>(1,1,1.0);
+            Psi.push_front(A);
+
+            QPrev = Q;
+            BasisPrev = Basis;
+            if (Site == Lattice->GetUnitCell().begin())
+               Site = Lattice->GetUnitCell().end();
+         }
+         while (Start != -1);
+      }
+
+      if (Site != Lattice->GetUnitCell().end())
+      {
+         std::cerr << "fatal: The wavefunction unit cell size must be a multiple of the lattice unit cell size ("
+                   << Lattice->GetUnitCell().size() << ")." << std::endl;
+         return 1;
+      }
+
+      MPWavefunction Wavefunction;
+
+      if (Infinite)
+      {
+         VectorBasis Basis(SL);
+         Basis.push_back(QLast, 1);
+         RealDiagonalOperator Lambda = RealDiagonalOperator::make_identity(Basis);
+
+         // Find the QShift if the first and last quantum numbers are Abelian.
+         // If they are non-Abelian, then we require that the first and last quantum number are the same.
+         QuantumNumber QShift(SL);
+         QuantumNumberList QL = transform_targets(QPrev, adjoint(QLast));
+         if (QL.size() == 1)
+            QShift = QL[0];
+         else if (QPrev != QLast)
+         {
+            std::cerr << "fatal: Cannot have a nontrivial qshift in a non-Abelian quantum number." << std::endl;
+            return 1;
+         }
+
+         InfiniteWavefunctionLeft PsiOut = InfiniteWavefunctionLeft::ConstructFromOrthogonal(Psi, QShift, Lambda);
+         PsiOut.check_structure();
+
+         Wavefunction.Wavefunction() = std::move(PsiOut);
+      }
+      else if (Finite)
+      {
+         FiniteWavefunctionLeft PsiOut = FiniteWavefunctionLeft::Construct(Psi);
+         PsiOut.check_structure();
+
+         Wavefunction.Wavefunction() = std::move(PsiOut);
+      }
+
+      Wavefunction.AppendHistoryCommand(EscapeCommandline(argc, argv));
+      Wavefunction.SetDefaultAttributes();
+
+      pvalue_ptr<MPWavefunction> PsiPtr(new MPWavefunction(Wavefunction));
+      pheap::ShutdownPersistent(PsiPtr);
+   }
+   catch (prog_opt::error& e)
+   {
+      std::cerr << "Exception while processing command line options: " << e.what() << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (pheap::PHeapCannotCreateFile& e)
+   {
+      std::cerr << "Exception: " << e.what() << std::endl;
+      if (e.Why == "File exists")
+         std::cerr << "Note: Use --force (-f) option to overwrite." << std::endl;
+      return 1;
+   }
+   catch (std::exception& e)
+   {
+      std::cerr << "Exception: " << e.what() << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (...)
+   {
+      std::cerr << "Unknown exception!" << std::endl;
+      pheap::Cleanup();
+      return 1;
+   }
+}


### PR DESCRIPTION
Closes #5.

At the moment, we can read two types of input strings:
* The quantum number at each bond is specified in brackets, and the local states are placed between the brackets, e.g. `(0.5)1(0.5)` or `(0.5) 1 (0.5)` for the AKLT state (the whitespace is ignored properly).
* Only the local basis states are specified, state labels are separated by a combination of `:` and whitespace, so `1:0:1:0`, `1 0 1 0` and `1:0 1 : 0` all work. (I don't think I could get `1010` to work very easily.)

The tool outputs an infinite wavefunction if `--infinite` is given, and a finite wavefunction if `--finite` is: if neither is specified, it currently defaults to infinite.

TODO:
* I want to add better error messages if an incorrect state label or quantum number label is given, where the position of the incorrect label is pointed out (probably using a `ParserError`).
* If there is only one local basis state (e.g. in `spinchain-su2`), it should be possible to for it to be omitted, so `(0.5)(0.5)` gives the AKLT state.
* It only accepts strings with brackets or colons (not both), and it has two different loops to handle both cases: it might be possible to consolidate these into one loop and handle strings which only specify some of the quantum number labels (this would primarily be useful for specifying the boundary quantum number for an Abelian lattice). This may turn out to be too complicated, so I might not end up doing this.