### PR TITLE
Fix some functions with multiple arguments in the infinite parser

### DIFF
--- a/lattice/infinite-parser.cpp
+++ b/lattice/infinite-parser.cpp
@@ -740,7 +740,7 @@ struct InfiniteLatticeParser : public grammar<InfiniteLatticeParser>
          sum_kink_expression = str_p("sum_kink")
             >> '('
             >> num_cells
-            >> expression_string[push_sum_kink(self.Lattice, self.eval, self.Args)]
+            >> bracket_expression[push_sum_kink(self.Lattice, self.eval, self.Args)]
             >> ')';
 
          sum_k_expression = str_p("sum_k")
@@ -753,13 +753,13 @@ struct InfiniteLatticeParser : public grammar<InfiniteLatticeParser>
          sum_string_inner_expression = str_p("sum_string_inner")
             >> '('
             >> num_cells
-            >> expression_string[push_sum_string_inner(self.Lattice, self.eval, self.Args)]
+            >> bracket_expression[push_sum_string_inner(self.Lattice, self.eval, self.Args)]
             >> ')';
 
          sum_string_dot_expression = str_p("sum_string_dot")
             >> '('
             >> num_cells
-            >> expression_string[push_sum_string_dot(self.Lattice, self.eval, self.Args)]
+            >> bracket_expression[push_sum_string_dot(self.Lattice, self.eval, self.Args)]
             >> ')';
 
          sum_partial_expression = str_p("sum_partial")


### PR DESCRIPTION
Closes #35.

@ianmccul I think `sum_kink`, `sum_string_dot` and `sum_string_inner` are the only functions affected by this bug, but it would be nice if you could check.

I don't know whether it matters for functions like `sum_k` to leave it as `expression_string` or to change it to `bracket_expression`: all that would change is the error message if you pass too many arguments to the function, e.g. for `expression_string`
```
Exception: Parser error: Operator does not exist or wrong type: 'sum_k'
note: While parsing an infinite operator:
sum_k(1,Sz(0),Sz(0))
```
and for `bracket_expression`
```
Exception: Parser error: Failed to parse an expression
note: while parsing a unit cell operator:
Sz(0),Sz(0)
     ^^^^^^
note: While parsing an infinite operator:
sum_kink(1,Sz(0),Sz(0))
```