### PR TITLE
 Add versions of SolveHamiltonianMPO which return the full polynomials

### DIFF
--- a/mp-algorithms/triangular_mpo_solver.h
+++ b/mp-algorithms/triangular_mpo_solver.h
@@ -133,12 +133,12 @@ SolveHamiltonianMPO_Left(StateComponent& E, InfiniteWavefunctionLeft const& Psi,
                    BasicTriangularMPO const& Op, double Tol = DefaultTol, int Verbose = 0);
 
 std::complex<double>
-SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat,StateComponent& F, LinearWavefunction const& Psi,
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat, StateComponent& F, LinearWavefunction const& Psi,
                     QuantumNumber const& QShift, BasicTriangularMPO const& Op,
                     MatrixOperator const& Rho, double Tol = DefaultTol, int Verbose = 0);
 
 std::complex<double>
-SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat,StateComponent& F, InfiniteWavefunctionRight const& Psi,
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat, StateComponent& F, InfiniteWavefunctionRight const& Psi,
                     BasicTriangularMPO const& Op, double Tol = DefaultTol, int Verbose = 0);
 
 std::complex<double>

--- a/mp-algorithms/triangular_mpo_solver.h
+++ b/mp-algorithms/triangular_mpo_solver.h
@@ -115,6 +115,15 @@ SolveSimpleMPO_Right(std::vector<MatrixPolyType>& FMat,
 // it is implemented as the fixed point polynomial evaluated at n=0.
 
 std::complex<double>
+SolveHamiltonianMPO_Left(std::vector<MatrixPolyType>& EMat, StateComponent& E, LinearWavefunction const& Psi,
+                       QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                       MatrixOperator const& Rho, double Tol = DefaultTol, int Verbose = 0);
+
+std::complex<double>
+SolveHamiltonianMPO_Left(std::vector<MatrixPolyType>& EMat, StateComponent& E, InfiniteWavefunctionLeft const& Psi,
+                   BasicTriangularMPO const& Op, double Tol = DefaultTol, int Verbose = 0);
+
+std::complex<double>
 SolveHamiltonianMPO_Left(StateComponent& E, LinearWavefunction const& Psi,
                        QuantumNumber const& QShift, BasicTriangularMPO const& Op,
                        MatrixOperator const& Rho, double Tol = DefaultTol, int Verbose = 0);
@@ -122,6 +131,15 @@ SolveHamiltonianMPO_Left(StateComponent& E, LinearWavefunction const& Psi,
 std::complex<double>
 SolveHamiltonianMPO_Left(StateComponent& E, InfiniteWavefunctionLeft const& Psi,
                    BasicTriangularMPO const& Op, double Tol = DefaultTol, int Verbose = 0);
+
+std::complex<double>
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat,StateComponent& F, LinearWavefunction const& Psi,
+                    QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                    MatrixOperator const& Rho, double Tol = DefaultTol, int Verbose = 0);
+
+std::complex<double>
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat,StateComponent& F, InfiniteWavefunctionRight const& Psi,
+                    BasicTriangularMPO const& Op, double Tol = DefaultTol, int Verbose = 0);
 
 std::complex<double>
 SolveHamiltonianMPO_Right(StateComponent& F, LinearWavefunction const& Psi,

--- a/mp-algorithms/triangular_mpo_solver_simple.cpp
+++ b/mp-algorithms/triangular_mpo_solver_simple.cpp
@@ -252,13 +252,13 @@ SolveSimpleMPO_Right(std::vector<MatrixPolyType>& FMat,
 }
 
 std::complex<double>
-SolveHamiltonianMPO_Left(StateComponent& E, LinearWavefunction const& Psi,
-   QuantumNumber const& QShift, BasicTriangularMPO const& Op,
-   MatrixOperator const& Rho, double Tol, int Verbose)
+SolveHamiltonianMPO_Left(std::vector<MatrixPolyType>& EMat, StateComponent& E, LinearWavefunction const& Psi,
+                         QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                         MatrixOperator const& Rho, double Tol, int Verbose)
 {
    if (E.is_null())
       E = Initial_E(Op, Psi.Basis1());
-   std::vector<MatrixPolyType> EMat(E.size());
+   EMat = std::vector<MatrixPolyType>(E.size());
    for (int i = 0; i < E.size(); ++i)
    {
       if (!E[i].is_null())
@@ -297,24 +297,41 @@ SolveHamiltonianMPO_Left(StateComponent& E, LinearWavefunction const& Psi,
 }
 
 std::complex<double>
-SolveHamiltonianMPO_Left(StateComponent& E, InfiniteWavefunctionLeft const& Psi,
-   BasicTriangularMPO const& Op, double Tol, int Verbose)
+SolveHamiltonianMPO_Left(std::vector<MatrixPolyType>& EMat, StateComponent& E, InfiniteWavefunctionLeft const& Psi,
+                         BasicTriangularMPO const& Op, double Tol, int Verbose)
 {
    LinearWavefunction PsiLinear;
    RealDiagonalOperator Lambda;
    std::tie(PsiLinear, Lambda) = get_left_canonical(Psi);
    MatrixOperator Rho = delta_shift(Lambda*Lambda, Psi.qshift());
-   return SolveHamiltonianMPO_Left(E, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
+   return SolveHamiltonianMPO_Left(EMat, E, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
 }
 
 std::complex<double>
-SolveHamiltonianMPO_Right(StateComponent& F, LinearWavefunction const& Psi,
-   QuantumNumber const& QShift, BasicTriangularMPO const& Op,
-   MatrixOperator const& Rho, double Tol, int Verbose)
+SolveHamiltonianMPO_Left(StateComponent& E, LinearWavefunction const& Psi,
+                         QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                         MatrixOperator const& Rho, double Tol, int Verbose)
+{
+   std::vector<MatrixPolyType> EMat(E.size());
+   return SolveHamiltonianMPO_Left(EMat, E, Psi, QShift, Op, Rho, Tol, Verbose);
+}
+
+std::complex<double>
+SolveHamiltonianMPO_Left(StateComponent& E, InfiniteWavefunctionLeft const& Psi,
+                         BasicTriangularMPO const& Op, double Tol, int Verbose)
+{
+   std::vector<MatrixPolyType> EMat(E.size());
+   return SolveHamiltonianMPO_Left(EMat, E, Psi, Op, Tol, Verbose);
+}
+
+std::complex<double>
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat, StateComponent& F, LinearWavefunction const& Psi,
+                          QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                          MatrixOperator const& Rho, double Tol, int Verbose)
 {
    if (F.is_null())
       F = Initial_F(Op, Psi.Basis1());
-   std::vector<MatrixPolyType> FMat(F.size());
+   FMat = std::vector<MatrixPolyType>(F.size());
    for (int i = 0; i < F.size(); ++i)
    {
       if (!F[i].is_null())
@@ -355,12 +372,29 @@ SolveHamiltonianMPO_Right(StateComponent& F, LinearWavefunction const& Psi,
 }
 
 std::complex<double>
-SolveHamiltonianMPO_Right(StateComponent& F, InfiniteWavefunctionRight const& Psi,
-   BasicTriangularMPO const& Op, double Tol, int Verbose)
+SolveHamiltonianMPO_Right(std::vector<MatrixPolyType>& FMat, StateComponent& F, InfiniteWavefunctionRight const& Psi,
+                          BasicTriangularMPO const& Op, double Tol, int Verbose)
 {
    LinearWavefunction PsiLinear;
    RealDiagonalOperator Lambda;
    std::tie(Lambda, PsiLinear) = get_right_canonical(Psi);
    MatrixOperator Rho = delta_shift(Lambda*Lambda, adjoint(Psi.qshift()));
-   return SolveHamiltonianMPO_Right(F, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
+   return SolveHamiltonianMPO_Right(FMat, F, PsiLinear, Psi.qshift(), Op, Rho, Tol, Verbose);
+}
+
+std::complex<double>
+SolveHamiltonianMPO_Right(StateComponent& F, LinearWavefunction const& Psi,
+                          QuantumNumber const& QShift, BasicTriangularMPO const& Op,
+                          MatrixOperator const& Rho, double Tol, int Verbose)
+{
+   std::vector<MatrixPolyType> FMat(F.size());
+   return SolveHamiltonianMPO_Right(FMat, F, Psi, QShift, Op, Rho, Tol, Verbose);
+}
+
+std::complex<double>
+SolveHamiltonianMPO_Right(StateComponent& F, InfiniteWavefunctionRight const& Psi,
+                          BasicTriangularMPO const& Op, double Tol, int Verbose)
+{
+   std::vector<MatrixPolyType> FMat(F.size());
+   return SolveHamiltonianMPO_Right(FMat, F, Psi, Op, Tol, Verbose);
 }


### PR DESCRIPTION
These were on the ea-solvers branch.

Doubling the number of SolveHamiltonianMPO functions doesn't seem right to me, but I don't know if there is a better way of doing this.

The current use for these on the ea-solvers branch is because in mp-excitation-ansatz, the full polynomials of the E and F matrices are (probably?) needed for the EA MPO solvers when the Hamiltonian is higher-order.