### PR TITLE
Fix coarsegraining for finite and IBC wavefunctions

### DIFF
--- a/lattice/unitcell_mpo.cpp
+++ b/lattice/unitcell_mpo.cpp
@@ -107,16 +107,16 @@ UnitCellMPO::ExtendToCover(int OtherSize, int OtherOffset)
    if (Offset > OtherOffset)
    {
       // need to extend this operator at the front with JW strings
-      Op = join(repeat(string_mpo(*SiteList, Com.SignOperator(), Op.qn1()),
-                       (Offset-OtherOffset) / SiteList->size()), Op);
+      Op = join(coarse_grain(repeat(string_mpo(*SiteList, Com.SignOperator(), Op.qn1()),
+                (Offset-OtherOffset) * CoarseGrain / SiteList->size()), CoarseGrain), Op);
       Offset = OtherOffset;
    }
 
    // do we need to extend the operator on the right?
    if (Offset+Op.size() < OtherOffset+OtherSize)
    {
-      Op = join(Op, repeat(identity_mpo(*SiteList, Op.qn2()),
-                           (OtherOffset+OtherSize-Offset-Op.size())/SiteList->size()));
+      Op = join(Op, coarse_grain(repeat(identity_mpo(*SiteList, Op.qn2()),
+                (OtherOffset+OtherSize-Offset-Op.size()) * CoarseGrain / SiteList->size()), CoarseGrain));
    }
 }
 

--- a/lattice/unitcell_mpo.h
+++ b/lattice/unitcell_mpo.h
@@ -240,7 +240,8 @@ UnitCellMPO ExtendToCoverUnitCell(UnitCellMPO const& Op, int OtherSize)
 inline
 UnitCellMPO coarse_grain(UnitCellMPO const& Op, int N)
 {
-   return UnitCellMPO(Op.SiteList, coarse_grain(ExtendToCoverUnitCell(Op,N).Op, N), Op.Com, Op.Offset, Op.Description,
+   return UnitCellMPO(Op.SiteList, coarse_grain(ExtendToCoverUnitCell(Op,N).Op, N), Op.Com,
+                      numerics::divp(Op.Offset, N).quot, Op.Description,
 		      Op.CoarseGrain*N);
 }
 


### PR DESCRIPTION
- Support for finite wavefunctions could also be added to `mp-finegrain`.
- Some other functions in lattice/unitcell_mpo.cpp don't look right (e.g. `GetJWStringUnit`), but since I don't where they are used or even if they are used at all, I wont't be able to test them, and so I didn't try to fix them.