### PR TITLE
Avoid some O(m^3) operations when reshaping tensors

### DIFF
--- a/mp-algorithms/tdvp.cpp
+++ b/mp-algorithms/tdvp.cpp
@@ -501,18 +501,16 @@ TDVP::ExpandLeftBond()
 
    // Construct new basis.
    SumBasis<VectorBasis> NewBasis((*CNext).Basis2(), U.Basis2());
-   // Construct a unitary to regularize the new basis.
-   MatrixOperator UReg = Regularize(NewBasis);
+   // Regularize the new basis.
+   Regularizer R(NewBasis);
 
    MaxStates = std::max(MaxStates, NewBasis.total_dimension());
 
    // Add the new states to CNext, and add zeros to C.
-   *CNext = tensor_row_sum(*CNext, prod(NL, U), NewBasis);
-   *CNext = prod(*CNext, herm(UReg));
+   *CNext = RegularizeBasis2(tensor_row_sum(*CNext, prod(NL, U), NewBasis), R);
 
    StateComponent Z = StateComponent((*C).LocalBasis(), Vh.Basis1(), (*C).Basis2());
-   *C = tensor_col_sum(*C, Z, NewBasis);
-   *C = prod(UReg, *C);
+   *C = RegularizeBasis1(R, tensor_col_sum(*C, Z, NewBasis));
 
    if (Verbose > 1)
    {
@@ -571,7 +569,7 @@ TDVP::EvolveExpand()
       Time += (*Gamma)*Timestep;
       ++Gamma;
    }
-   
+
    this->UpdateHamiltonianRight(Time, (*Gamma)*Timestep);
 
    if (Epsilon)
@@ -800,7 +798,7 @@ TDVP::Evolve2()
       Time += (*Gamma)*Timestep;
       ++Gamma;
    }
-   
+
    if (Epsilon)
       this->CalculateEps();
 }

--- a/mp-algorithms/write-matrix.cpp
+++ b/mp-algorithms/write-matrix.cpp
@@ -21,20 +21,12 @@
 #include "tensor/basis.h"
 #include "tensor/regularize.h"
 
-MatrixOperator
-Regularize(MatrixOperator const& M)
-{
-   MatrixOperator U = Regularize(M.Basis1());
-   MatrixOperator V = Regularize(M.Basis2());
-   return U * M * herm(V);
-}
-
 StateComponent
 Regularize(StateComponent const& M)
 {
-   MatrixOperator U = Regularize(M.Basis1());
-   MatrixOperator V = Regularize(M.Basis2());
-   return prod(U, prod(M, herm(V)));
+   Regularizer R1(M.Basis1());
+   Regularizer R2(M.Basis2());
+   return RegularizeBasis12(R1, M, R2);
 }
 
 //

--- a/mp/mp-matrix.cpp
+++ b/mp/mp-matrix.cpp
@@ -41,14 +41,6 @@ bool FileExists(std::string const& Name)
    return stat(Name.c_str(), &buf) != -1 && S_ISREG(buf.st_mode);
 }
 
-MatrixOperator
-Regularize(MatrixOperator const& M)
-{
-   Regularizer R1(M.Basis1());
-   Regularizer R2(M.Basis2());
-   return RegularizeBasis12(R1, M, R2);
-}
-
 int main(int argc, char** argv)
 {
    try

--- a/mp/mp-matrix.cpp
+++ b/mp/mp-matrix.cpp
@@ -42,11 +42,11 @@ bool FileExists(std::string const& Name)
 }
 
 MatrixOperator
-RegularizeM(MatrixOperator const& M)
+Regularize(MatrixOperator const& M)
 {
-   MatrixOperator U = Regularize(M.Basis1());
-   MatrixOperator V = Regularize(M.Basis2());
-   return U * M * herm(V);
+   Regularizer R1(M.Basis1());
+   Regularizer R2(M.Basis2());
+   return RegularizeBasis12(R1, M, R2);
 }
 
 int main(int argc, char** argv)
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
       RealDiagonalOperator D;
       std::tie(PsiL, D) = get_left_canonical(InfPsi);
       MatrixOperator Rho = D;
-      Rho = RegularizeM(scalar_prod(Rho, herm(Rho)));
+      Rho = Regularize(scalar_prod(Rho, herm(Rho)));
       if (Rho.size1() != 1 || Rho.size2() != 1)
       {
          std::cerr << "mp-matrix: error: mps has non-trivial symmetries.\n";

--- a/mps/state_component.cpp
+++ b/mps/state_component.cpp
@@ -18,6 +18,7 @@
 // ENDHEADER
 
 #include "state_component.h"
+#include "density.h"
 #include "common/openmp.h"
 #include "quantumnumbers/quantumnumber.h"
 #include "quantumnumbers/u1.h"
@@ -25,6 +26,8 @@
 #include <tuple>
 #include "linearalgebra/matrix_utility.h"
 #include "tensor/tensor_eigen.h"
+
+double const EigenvalueEpsilon = std::numeric_limits<double>::epsilon() * 4;
 
 StateComponent make_vacuum_state(QuantumNumbers::SymmetryList const& S)
 {
@@ -840,26 +843,183 @@ ExpandBasis1_(StateComponent const& A)
 std::pair<RealDiagonalOperator, MatrixOperator>
 OrthogonalizeBasis2(StateComponent& A)
 {
-   // TODO: optimize this implementation
-
    MatrixOperator U, Vh;
    RealDiagonalOperator D;
-   MatrixOperator M = ExpandBasis2(A);
+   MatrixOperator M = ReshapeBasis1(A);   // M is md x m
    SingularValueDecomposition(M, U, D, Vh);
-   A = prod(A, U);
+   A = ReshapeFromBasis1(U, A.LocalBasis(), A.Basis1());
    return std::make_pair(D, Vh);
 }
 
 std::pair<MatrixOperator, RealDiagonalOperator>
 OrthogonalizeBasis1(StateComponent& A)
 {
-   // TODO: optimize this implementation
    MatrixOperator U, Vh;
    RealDiagonalOperator D;
-   MatrixOperator M = ExpandBasis1(A);
+   MatrixOperator M = ReshapeBasis2(A);
    SingularValueDecomposition(M, U, D, Vh);
-   A = prod(Vh, A);
+   A = ReshapeFromBasis2(Vh, A.LocalBasis(), A.Basis2());
    return std::make_pair(U, D);
+}
+
+MatrixOperator ReshapeBasis1(StateComponent const& A)
+{
+   // TODO: we should make a regular basis
+   ProductBasis<VectorBasis, BasisList> FullBasis1(A.Basis1(), adjoint(A.LocalBasis()));
+   MatrixOperator Result(FullBasis1.Basis(), A.Basis2());
+   for (int s = 0; s < A.size(); ++s)
+   {
+      for (auto I = iterate(A[s]); I; ++I)
+      {
+         for (auto J = iterate(I); J; ++J)
+         {
+            // Find the element in FullBasis1 that matches the quantum number
+            // **TODO** This will have an outer multiplicity problem
+            auto t = FullBasis1.begin(I.index(), s);
+            while (t != FullBasis1.end(I.index(), s) && FullBasis1[*t] != A.Basis2()[J.index2()])
+               ++t;
+            if (t != FullBasis1.end(I.index(), s))
+            {
+               // Scale factor for non-abelian symmetries sqrt(qdim(index1) / qdim(index2))
+               Result(*t, J.index2()) = (*J) * std::sqrt(double(degree(A.Basis1()[I.index1()])) / degree(A.Basis2()[J.index2()]));
+            }
+         }
+      }
+   }
+   return Result;
+}
+
+StateComponent ReshapeFromBasis1(MatrixOperator const& X, BasisList const& LB, VectorBasis const& B1)
+{
+   ProductBasis<VectorBasis, BasisList> FullBasis1(B1, adjoint(LB));
+   CHECK_EQUAL(X.Basis1(), FullBasis1.Basis());
+   StateComponent Result(LB, B1, X.Basis2());
+   for (auto I = iterate(X); I; ++I)
+   {
+      auto t = FullBasis1.rmap(I.index());
+      for (auto J = iterate(I); J; ++J)
+      {
+         // Scale factor for non-abelian symmetries
+         Result[t.second](t.first, J.index2()) = (*J) * std::sqrt(double(degree(X.Basis2()[J.index2()])) / degree(B1[t.first]));
+      }
+   }
+   return Result;
+}
+
+MatrixOperator ReshapeBasis2(StateComponent const& A)
+{
+   // TODO: we should make a regular basis
+   ProductBasis<BasisList, VectorBasis> FullBasis2(A.LocalBasis(), A.Basis2());
+   MatrixOperator Result(A.Basis1(), FullBasis2.Basis());
+   for (int s = 0; s < A.size(); ++s)
+   {
+      for (auto I = iterate(A[s]); I; ++I)
+      {
+         for (auto J = iterate(I); J; ++J)
+         {
+            // Find the element in FullBasis2 that matches the quantum number
+            // **TODO** This will have an outer multiplicity problem
+            auto t = FullBasis2.begin(s, J.index2());
+            while (t != FullBasis2.end(s, J.index2()) && FullBasis2[*t] != A.Basis1()[I.index()])
+               ++t;
+            if (t != FullBasis2.end(s, J.index2()))
+            {
+               // No scale factor in this case - the coupling coefficient is 1.0
+               Result(I.index(), *t) = *J;
+            }
+         }
+      }
+   }
+   return Result;
+}
+
+StateComponent ReshapeFromBasis2(MatrixOperator const& X, BasisList const& LB, VectorBasis const& B2)
+{
+   ProductBasis<BasisList, VectorBasis> FullBasis2(LB, B2);
+   CHECK_EQUAL(X.Basis2(), FullBasis2.Basis());
+   StateComponent Result(LB, X.Basis1(), B2);
+   for (auto I = iterate(X); I; ++I)
+   {
+      for (auto J = iterate(I); J; ++J)
+      {
+         auto t = FullBasis2.rmap(J.index2());
+         Result[t.first](I.index(), t.second) = *J;
+      }
+   }
+   return Result;
+}
+
+StateComponent RegularizeBasis1(Regularizer const& R, StateComponent const& M)
+{
+   StateComponent Result(M.LocalBasis(), R.Basis(), M.Basis2());
+   for (int i = 0; i < M.size(); ++i)
+   {
+      Result[i] = RegularizeBasis1(R, M[i]);
+   }
+   return Result;
+}
+
+StateComponent RegularizeBasis2(StateComponent const& M, Regularizer const& R)
+{
+   StateComponent Result(M.LocalBasis(), M.Basis1(), R.Basis());
+   for (int i = 0; i < M.size(); ++i)
+   {
+      Result[i] = RegularizeBasis2(M[i], R);
+   }
+   return Result;
+}
+
+StateComponent RegularizeBasis12(Regularizer const& R1, StateComponent const& M, Regularizer const& R2)
+{
+   StateComponent Result(M.LocalBasis(), R1.Basis(), R2.Basis());
+   for (int i = 0; i < M.size(); ++i)
+   {
+      Result[i] = RegularizeBasis12(R1, M[i], R2);
+   }
+   return Result;
+}
+
+StateComponent
+NullSpace1(StateComponent A)
+{
+   StateComponent AOriginal = A;
+   typedef StateComponent::operator_type operator_type;
+   operator_type Trunc = ExpandBasis1(A);  // the original component is prod(Trunc, A), Trunc is m x dm matrix
+   // Do the singular value decomposition via a (reduced) density matrix
+   DensityMatrix<operator_type> DM(scalar_prod(herm(Trunc), Trunc)); // DM is a dm x dm matrix
+
+   //   DM.DensityMatrixReport(std::cerr);
+   DensityMatrix<operator_type>::const_iterator E = DM.begin();
+   // take all eigenvalues that are bigger than EigenvalueEpsilon (normalized to EigenSum)
+   while (E != DM.end() && E->Eigenvalue > EigenvalueEpsilon * DM.EigenSum()) ++E;
+   operator_type UOriginal = DM.ConstructTruncator(DM.begin(), E);
+   operator_type UTangent = DM.ConstructTruncator(E, DM.end());
+
+   // original A is Trunc * herm(UOriginal) * UOriginal * A  [final A]
+   DEBUG_CHECK(norm_frob(AOriginal - prod(Trunc * herm(UOriginal) * UOriginal, A)) < 1E-10);
+   StateComponent ANew = prod(UTangent, A);
+
+   DEBUG_CHECK(norm_frob(scalar_prod(AOriginal, herm(ANew))) < 1E-10);
+
+   return ANew;
+}
+
+StateComponent
+NullSpace2(StateComponent A)
+{
+   typedef StateComponent::operator_type OperatorType;
+   OperatorType Trunc = ExpandBasis2(A);  // the original component is prod(A, Trunc)
+   // Do the singular value decomposition via a (reduced) density matrix
+   DensityMatrix<OperatorType> DM(scalar_prod(Trunc, herm(Trunc)));
+
+   // DM.DensityMatrixReport(std::cerr);
+   DensityMatrix<OperatorType>::const_iterator E = DM.begin();
+   // take all eigenvalues that are bigger than EigenvalueEpsilon (normalized to EigenSum)
+   while (E != DM.end() && E->Eigenvalue > EigenvalueEpsilon * DM.EigenSum()) ++E;
+   OperatorType UOriginal = DM.ConstructTruncator(DM.begin(), E);
+   OperatorType UTangent = DM.ConstructTruncator(E, DM.end());
+
+   return prod(A, herm(UTangent));
 }
 
 StateComponent ConstructFromRightBasis(BasisList const& LocalBasis,

--- a/mps/state_component.cpp
+++ b/mps/state_component.cpp
@@ -979,6 +979,14 @@ StateComponent RegularizeBasis12(Regularizer const& R1, StateComponent const& M,
    return Result;
 }
 
+MatrixOperator
+Regularize(MatrixOperator const& M)
+{
+   Regularizer R1(M.Basis1());
+   Regularizer R2(M.Basis2());
+   return RegularizeBasis12(R1, M, R2);
+}
+
 StateComponent
 NullSpace1(StateComponent A)
 {

--- a/mps/state_component.h
+++ b/mps/state_component.h
@@ -714,6 +714,7 @@ StateComponent NullSpace1(StateComponent A);
 StateComponent NullSpace2(StateComponent A);
 
 // Reshape A-matrix into (dm)x(m) matrix
+// The reshaped basis is a regular basis.
 MatrixOperator ReshapeBasis1(StateComponent const& A);
 StateComponent ReshapeFromBasis1(MatrixOperator const& X, BasisList const& LB, VectorBasis const& B1);
 

--- a/mps/state_component.h
+++ b/mps/state_component.h
@@ -28,6 +28,7 @@
 #include "tensor/tensorsum.h"
 #include "tensor/basis.h"
 #include "tensor/tensorproduct.h"
+#include "tensor/regularize.h"
 #include "linearalgebra/scalarmatrix.h"
 
 using namespace Tensor;
@@ -693,13 +694,42 @@ StateComponent CoerceSymmetryList(StateComponent const& Op, SymmetryList const& 
 
 enum Normalization { Intensive, Extensive };
 
+// Expands the Basis1 of A so that it is dm dimensional and orthogonalized, such that
+// A = Result' * A', and Result' is a m x dm matrix
 MatrixOperator ExpandBasis1(StateComponent& A);
+
+// Expands the Basis2 of A so that it is dm dimensional and orthogonalized, such that
+// A = A' * Result', and Result' is a dm x m matrix
 MatrixOperator ExpandBasis2(StateComponent& A);
 
 // Expand the basis, but incorporate only those matrix elements that are actually used in
 // the A-matrix.  Zero matrix elements are excluded.
 MatrixOperator ExpandBasis1Used(StateComponent& A, std::vector<int> const& Used);
 MatrixOperator ExpandBasis2Used(StateComponent& A, std::vector<int> const& Used);
+
+// Get the null-space of Basis 1 of A.  A is assumed to be right-orthogonal.
+StateComponent NullSpace1(StateComponent A);
+
+// Get the null-space of Basis 2 of A.  A is assumed to be left-orthogonal.
+StateComponent NullSpace2(StateComponent A);
+
+// Reshape A-matrix into (dm)x(m) matrix
+MatrixOperator ReshapeBasis1(StateComponent const& A);
+StateComponent ReshapeFromBasis1(MatrixOperator const& X, BasisList const& LB, VectorBasis const& B1);
+
+// Reshape A-matrix into (m)x(dm) matrix
+MatrixOperator ReshapeBasis2(StateComponent const& A);
+StateComponent ReshapeFromBasis2(MatrixOperator const& X, BasisList const& LB, VectorBasis const& B2);
+
+// Regularize a StateComponent
+StateComponent RegularizeBasis1(Regularizer const& R, StateComponent const& M);
+StateComponent RegularizeBasis2(StateComponent const& M, Regularizer const& R);
+StateComponent RegularizeBasis12(Regularizer const& R1, StateComponent const& M, Regularizer const& R2);
+
+// Shortcut function, when we just want to regularize an operator and we don't care what the Regularizer is
+MatrixOperator Regularize(MatrixOperator const& M);
+
+// We could also unregularize a StateComponent, but so far we don't need it
 
 // left-orthogonalizes an MPS
 // basically equivalent to ExpandBasis2() followed by an SVD

--- a/tensor/regularize.cc
+++ b/tensor/regularize.cc
@@ -20,6 +20,18 @@
 namespace Tensor
 {
 
+inline
+int Regularizer::IndexOf(int i) const
+{
+   return BasisMappingIndex[i];
+}
+
+inline
+LinearAlgebra::Range Regularizer::RangeOf(int i) const
+{
+   return BasisMappingRange[i];
+}
+
 template <typename T>
 IrredTensor<T, BasisList, BasisList>
 map_1x1_operator(IrredTensor<LinearAlgebra::Matrix<T>, BasisList, BasisList> const& Op)
@@ -53,9 +65,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 RegularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M)
 {
-   if (R.is_trivial())
-      return M;
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R.Basis(), M.Basis2(), M.TransformsAs());
    for (auto I = iterate(M); I; ++I)
    {
@@ -77,9 +86,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 UnregularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M)
 {
-   if (R.is_trivial())
-      return M;
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R.OriginalBasis(), M.Basis2(), M.TransformsAs());
    for (int i = 0; i < Result.Basis1().size(); ++i)
    {
@@ -99,9 +105,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 RegularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R)
 {
-   if (R.is_trivial())
-      return M;
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(M.Basis1(), R.Basis(), M.TransformsAs());
    for (auto I = iterate(M); I; ++I)
    {
@@ -123,9 +126,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 UnregularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R)
 {
-   if (R.is_trivial())
-      return M;
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(M.Basis1(), R.OriginalBasis(), M.TransformsAs());
    for (int i = 0; i < Result.Basis1().size(); ++i)
    {
@@ -145,13 +145,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 RegularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2)
 {
-   if (R1.is_trivial() && R2.is_trivial())
-      return M;
-   else if (R1.is_trivial())
-      return RegularizeBasis2(M, R2);
-   else if (R2.is_trivial())
-      return RegularizeBasis1(R1, M);
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R1.Basis(), R2.Basis(), M.TransformsAs());
    for (auto I = iterate(M); I; ++I)
    {
@@ -173,13 +166,6 @@ template <typename T>
 IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
 UnregularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2)
 {
-   if (R1.is_trivial() && R2.is_trivial())
-      return M;
-   else if (R1.is_trivial())
-      return UnregularizeBasis2(M, R2);
-   else if (R2.is_trivial())
-      return UnregularizeBasis1(R1, M);
-
    IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R1.OriginalBasis(), R2.OriginalBasis(), M.TransformsAs());
    for (int i = 0; i < Result.Basis1().size(); ++i)
    {

--- a/tensor/regularize.cc
+++ b/tensor/regularize.cc
@@ -49,4 +49,165 @@ ToMatrixOperator(IrredTensor<T, BasisList, BasisList> const& Op)
    return Result;
 }
 
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M)
+{
+   if (R.is_trivial())
+      return M;
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R.Basis(), M.Basis2(), M.TransformsAs());
+   for (auto I = iterate(M); I; ++I)
+   {
+      for (auto J = iterate(I); J; ++J)
+      {
+         auto r = iterate_at(Result.data(), R.IndexOf(J.index1()), J.index2());
+         if (!r)
+         {
+            Result(R.IndexOf(J.index1()), J.index2()) = LinearAlgebra::Matrix<T>(R.Basis().dim(R.IndexOf(J.index1())), M.Basis2().dim(J.index2()), 0.0);
+            r = iterate_at(Result.data(), R.IndexOf(J.index1()), J.index2());
+         }
+         (*r)(R.RangeOf(J.index1()), LinearAlgebra::all) = *J;
+      }
+   }
+   return Result;
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M)
+{
+   if (R.is_trivial())
+      return M;
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R.OriginalBasis(), M.Basis2(), M.TransformsAs());
+   for (int i = 0; i < Result.Basis1().size(); ++i)
+   {
+      for (int j = 0; j < Result.Basis2().size(); ++j)
+      {
+         auto r = iterate_at(M.data(), R.IndexOf(i), j);
+         if (r)
+         {
+            Result(i,j) = (*r)(R.RangeOf(i), LinearAlgebra::all);
+         }
+      }
+   }
+   return Result;
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R)
+{
+   if (R.is_trivial())
+      return M;
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(M.Basis1(), R.Basis(), M.TransformsAs());
+   for (auto I = iterate(M); I; ++I)
+   {
+      for (auto J = iterate(I); J; ++J)
+      {
+         auto r = iterate_at(Result.data(), J.index1(), R.IndexOf(J.index2()));
+         if (!r)
+         {
+            Result(J.index1(), R.IndexOf(J.index2())) = LinearAlgebra::Matrix<T>(M.Basis1().dim(J.index1()), R.Basis().dim(R.IndexOf(J.index2())), 0.0);
+            r = iterate_at(Result.data(), J.index1(), R.IndexOf(J.index2()));
+         }
+         (*r)(LinearAlgebra::all, R.RangeOf(J.index2())) = *J;
+      }
+   }
+   return Result;
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R)
+{
+   if (R.is_trivial())
+      return M;
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(M.Basis1(), R.OriginalBasis(), M.TransformsAs());
+   for (int i = 0; i < Result.Basis1().size(); ++i)
+   {
+      for (int j = 0; j < Result.Basis2().size(); ++j)
+      {
+         auto r = iterate_at(M.data(), i, R.IndexOf(j));
+         if (r)
+         {
+            Result(i,j) = (*r)(LinearAlgebra::all, R.RangeOf(j));
+         }
+      }
+   }
+   return Result;
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2)
+{
+   if (R1.is_trivial() && R2.is_trivial())
+      return M;
+   else if (R1.is_trivial())
+      return RegularizeBasis2(M, R2);
+   else if (R2.is_trivial())
+      return RegularizeBasis1(R1, M);
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R1.Basis(), R2.Basis(), M.TransformsAs());
+   for (auto I = iterate(M); I; ++I)
+   {
+      for (auto J = iterate(I); J; ++J)
+      {
+         auto r = iterate_at(Result.data(), R1.IndexOf(J.index1()), R2.IndexOf(J.index2()));
+         if (!r)
+         {
+            Result(R1.IndexOf(J.index1()), R2.IndexOf(J.index2())) = LinearAlgebra::Matrix<T>(R1.Basis().dim(R1.IndexOf(J.index1())), R2.Basis().dim(R2.IndexOf(J.index2())), 0.0);
+            r = iterate_at(Result.data(), R1.IndexOf(J.index1()), R2.IndexOf(J.index2()));
+         }
+         (*r)(R1.RangeOf(J.index1()), R2.RangeOf(J.index2())) = *J;
+      }
+   }
+   return Result;
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2)
+{
+   if (R1.is_trivial() && R2.is_trivial())
+      return M;
+   else if (R1.is_trivial())
+      return UnregularizeBasis2(M, R2);
+   else if (R2.is_trivial())
+      return UnregularizeBasis1(R1, M);
+
+   IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> Result(R1.OriginalBasis(), R2.OriginalBasis(), M.TransformsAs());
+   for (int i = 0; i < Result.Basis1().size(); ++i)
+   {
+      for (int j = 0; j < Result.Basis2().size(); ++j)
+      {
+         auto r = iterate_at(M.data(), R1.IndexOf(i), R2.IndexOf(i));
+         if (r)
+         {
+            Result(i,j) = (*r)(R1.RangeOf(i), R2.RangeOf(j));
+         }
+      }
+   }
+   return Result;
+}
+
+
+template <typename T>
+IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure>
+RegularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure> const& M, Regularizer const& R2)
+{
+   PANIC("Not implemented");
+}
+
+template <typename T>
+IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure>
+UnregularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure> const& M, Regularizer const& R2)
+{
+   PANIC("Not implemented");
+}
+
 } // namespace Tensor

--- a/tensor/regularize.cpp
+++ b/tensor/regularize.cpp
@@ -24,14 +24,6 @@ namespace Tensor
 
 Regularizer::Regularizer(VectorBasis const& b)
 {
-   if (is_regular_basis(b))
-   {
-      Trivial = true;
-      RegularBasis = b;
-      return;
-   }
-
-   Trivial = false;
    IrregularBasis = b;
    // Iterate through b and determine the total dimension of
    // each quantum number space, and also map the subspaces of b
@@ -60,16 +52,6 @@ Regularizer::Regularizer(VectorBasis const& b)
    {
       BasisMappingIndex.push_back(IndexOfQ[b[i]]);
    }
-}
-
-int Regularizer::IndexOf(int i) const
-{
-   return Trivial ? 1 : BasisMappingIndex[i];
-}
-
-LinearAlgebra::Range Regularizer::RangeOf(int i) const
-{
-   return Trivial ? LinearAlgebra::Range(0, RegularBasis.dim(i)) : BasisMappingRange[i];
 }
 
 bool is_regular_basis(VectorBasis const& b)

--- a/tensor/regularize.h
+++ b/tensor/regularize.h
@@ -33,9 +33,6 @@ class Regularizer
 
       explicit Regularizer(VectorBasis const& b);
 
-      // returns true if the regularizer is trivial, i.e. the original basis was already regular.
-      bool is_trivial() const { return Trivial; }
-
       // returns the index into the regular basis of the component i
       int IndexOf(int i) const;
 
@@ -44,11 +41,10 @@ class Regularizer
 
       VectorBasis const& Basis() const { return RegularBasis; }
 
-      VectorBasis const& OriginalBasis() const { return this->is_trivial() ? RegularBasis : IrregularBasis; }
+      VectorBasis const& OriginalBasis() const { return IrregularBasis; }
 
 
    private:
-      bool                              Trivial;
       std::vector<int>                  BasisMappingIndex;
       std::vector<LinearAlgebra::Range> BasisMappingRange;
       VectorBasis                       IrregularBasis;

--- a/tensor/regularize.h
+++ b/tensor/regularize.h
@@ -25,19 +25,83 @@
 namespace Tensor
 {
 
-// Regularizes the basis, returns the transform matrix.
-// The regular basis is Result'.Basis1()
-// Result'.Basis2() is b.
-IrredTensor<LinearAlgebra::Matrix<double>, VectorBasis, VectorBasis>
-Regularize(VectorBasis const& b);
+// Class to keep track of the index mapping for mapping a VectorBasis onto a regular basis
+class Regularizer
+{
+   public:
+      Regularizer() = delete;
+
+      explicit Regularizer(VectorBasis const& b);
+
+      // returns true if the regularizer is trivial, i.e. the original basis was already regular.
+      bool is_trivial() const { return Trivial; }
+
+      // returns the index into the regular basis of the component i
+      int IndexOf(int i) const;
+
+      // returns the range mapping of the component i in the regular basis
+      LinearAlgebra::Range RangeOf(int i) const;
+
+      VectorBasis const& Basis() const { return RegularBasis; }
+
+      VectorBasis const& OriginalBasis() const { return this->is_trivial() ? RegularBasis : IrregularBasis; }
+
+
+   private:
+      bool                              Trivial;
+      std::vector<int>                  BasisMappingIndex;
+      std::vector<LinearAlgebra::Range> BasisMappingRange;
+      VectorBasis                       IrregularBasis;
+      VectorBasis                       RegularBasis;
+};
+
+// Regularize Basis1 of a tensor, more efficiently than multiplying by the transformation tensor.
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M);
+
+// Regularize Basis2 of a tensor, more efficiently than multiplying by the transformation tensor.
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R);
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+RegularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2);
+
+// Not yet implemented
+template <typename T>
+IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure>
+RegularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure> const& M, Regularizer const& R2);
+
+// Inverse of Regularize
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis1(Regularizer const& R, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M);
+
+// Regularize Basis2 of a tensor, more efficiently than multiplying by the transformation tensor.
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis2(IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R);
+
+template <typename T>
+IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis>
+UnregularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::Matrix<T>, VectorBasis, VectorBasis> const& M, Regularizer const& R2);
+
+// Not yet implemented
+template <typename T>
+IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure>
+UnregularizeBasis12(Regularizer const& R1, IrredTensor<LinearAlgebra::DiagonalMatrix<T>, VectorBasis, VectorBasis, Tensor::DiagonalStructure> const& M, Regularizer const& R2);
+
+// Legacy Regularize for BasisList.  This would be better viewed as mapping a BasisList to a VectorBasis,
+// with the inverse operation being SplitBasis (better renamed as something else?)
+
+IrredTensor<LinearAlgebra::Matrix<double>, VectorBasis, BasisList>
+Regularize(BasisList const& b);
 
 // is_regular_basis
 // Returns true if the basis is regular
 bool is_regular_basis(VectorBasis const& b);
-
-// regularize a BasisList
-IrredTensor<LinearAlgebra::Matrix<double>, VectorBasis, BasisList>
-Regularize(BasisList const& b);
 
 // split a VectorBasis into a BasisList.  Returns the transpose of the tranform matrix
 IrredTensor<LinearAlgebra::Matrix<double>, VectorBasis, BasisList>

--- a/tensor/tensor_exponential.cpp
+++ b/tensor/tensor_exponential.cpp
@@ -80,10 +80,8 @@ exp(IrredTensor<LinearAlgebra::Matrix<std::complex<double>>, VectorBasis, Vector
 
    if (!is_regular_basis(m.Basis1()))
    {
-      IrredTensor<LinearAlgebra::Matrix<double>, VectorBasis, VectorBasis> X
-         = Regularize(m.Basis1());
-
-      return triple_prod(herm(X), exp(triple_prod(X, m, herm(X))), X);
+      Regularizer R(m.Basis1());
+      return UnregularizeBasis12(R, exp(RegularizeBasis12(R, m, R)), R);
    }
 
    IrredTensor<LinearAlgebra::Matrix<std::complex<double>>, VectorBasis, VectorBasis>

--- a/wavefunction/linearwavefunction.h
+++ b/wavefunction/linearwavefunction.h
@@ -422,51 +422,6 @@ TruncateBasis2(StateComponent& A)
    return prod(U, Trunc, QuantumNumber(Trunc.GetSymmetryList()));
 }
 
-inline
-StateComponent
-NullSpace1(StateComponent A)
-{
-   StateComponent AOriginal = A;
-   typedef StateComponent::operator_type operator_type;
-   operator_type Trunc = ExpandBasis1(A);  // the original component is prod(Trunc, A), Trunc is m x dm matrix
-   // Do the singular value decomposition via a (reduced) density matrix
-   DensityMatrix<operator_type> DM(scalar_prod(herm(Trunc), Trunc)); // DM is a dm x dm matrix
-
-   //   DM.DensityMatrixReport(std::cerr);
-   DensityMatrix<operator_type>::const_iterator E = DM.begin();
-   // take all eigenvalues that are bigger than EigenvalueEpsilon (normalized to EigenSum)
-   while (E != DM.end() && E->Eigenvalue > EigenvalueEpsilon * DM.EigenSum()) ++E;
-   operator_type UOriginal = DM.ConstructTruncator(DM.begin(), E);
-   operator_type UTangent = DM.ConstructTruncator(E, DM.end());
-
-   // original A is Trunc * herm(UOriginal) * UOriginal * A  [final A]
-   DEBUG_CHECK(norm_frob(AOriginal - prod(Trunc * herm(UOriginal) * UOriginal, A)) < 1E-10);
-   StateComponent ANew = prod(UTangent, A);
-
-   DEBUG_CHECK(norm_frob(scalar_prod(AOriginal, herm(ANew))) < 1E-10);
-
-   return ANew;
-}
-
-inline
-StateComponent
-NullSpace2(StateComponent A)
-{
-   typedef StateComponent::operator_type OperatorType;
-   OperatorType Trunc = ExpandBasis2(A);  // the original component is prod(A, Trunc)
-   // Do the singular value decomposition via a (reduced) density matrix
-   DensityMatrix<OperatorType> DM(scalar_prod(Trunc, herm(Trunc)));
-
-   // DM.DensityMatrixReport(std::cerr);
-   DensityMatrix<OperatorType>::const_iterator E = DM.begin();
-   // take all eigenvalues that are bigger than EigenvalueEpsilon (normalized to EigenSum)
-   while (E != DM.end() && E->Eigenvalue > EigenvalueEpsilon * DM.EigenSum()) ++E;
-   OperatorType UOriginal = DM.ConstructTruncator(DM.begin(), E);
-   OperatorType UTangent = DM.ConstructTruncator(E, DM.end());
-
-   return prod(A, herm(UTangent));
-}
-
 // template definitions
 
 template <typename FwdIter>


### PR DESCRIPTION
Added ReshapeBasis1/2 functions, as an O(m^2) replacement for ExpandBasis1(), ExpandBasis2() 

Replace Regularize(VectorBasis) functions with a Regularizer class to store the transformation and new functions RegularizeBasis{1|2|12}
