### PR TITLE
Changing local Hilbert spaces

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -224,7 +224,7 @@ tools = mp-idmrg-s3e mp-ioverlap \
         mp-irotate mp-icorrelation mp-itebd mp-coarsegrain mp-finegrain mp-dmrg mp-random \
         mp-expectation mp-overlap mp-scale mp-matrix mp-tebd mp-apply mp-normalize \
         mp-tdvp mp-itdvp mp-iexpectation-cross mp-imoments-cross mp-right-canonicalize mp-left-canonicalize \
-        mp-construct
+        mp-construct mp-change-lattice
 
 experimental-tools = mp-iprint mp-iproject mp-idmrg mp-iupdate mp-ibc-create mp-aux-project mp-ibc-dmrg mp-fluctuation
 

--- a/lattice/infinitelattice.cpp
+++ b/lattice/infinitelattice.cpp
@@ -568,8 +568,6 @@ BasicTriangularMPO sum_unit(SiteListType const& SiteList, BasicFiniteMPO const& 
    // which is the desired operator.  This is quite straightforward,
    // since X,A have 1 row, and F,I have 1 column.
 
-   DEBUG_TRACE(Op.size())(UnitCellSize)(SiteList.size());
-
    // To construct this operator, we firstly split Op into UnitCellSize pieces
    std::vector<std::vector<OperatorComponent>> SplitOp = SplitOperator(Op, UnitCellSize);
 

--- a/lattice/latticesite.cpp
+++ b/lattice/latticesite.cpp
@@ -91,6 +91,12 @@ LatticeSite::Basis2() const
    return this->operator[]("I").Basis2();
 }
 
+LatticeSite::basis1_type const&
+LatticeSite::Basis() const
+{
+   return this->Basis1();
+}
+
 void
 LatticeSite::set_operator_descriptions(OperatorDescriptions const& Desc)
 {

--- a/lattice/latticesite.h
+++ b/lattice/latticesite.h
@@ -25,6 +25,9 @@
 
   This also has a description, which is just used for informational
   purposes, eg "Fermion site", "Boson site", etc
+
+  A LatticeSite has a well-defined local Hilbert space, i.e. every operator that is part of the lattice site
+  has Basis1() == Basis2()
 */
 
 #if !defined(MPTOOLKIT_LATTICE_LATTICESITE_H)
@@ -81,6 +84,7 @@ class LatticeSite
       SymmetryList GetSymmetryList() const;
 
       // precondition: !empty()
+      basis1_type const& Basis() const;
       basis1_type const& Basis1() const;
       basis2_type const& Basis2() const;
 

--- a/lattice/unitcell.cpp
+++ b/lattice/unitcell.cpp
@@ -317,7 +317,13 @@ UnitCell::local_operator(std::string const& Op, int Cell, int n) const
 UnitCell::operator_type
 UnitCell::map_local_operator(SiteOperator const& Operator, int Cell, int n) const
 {
-   std::string SignOperator = Operator.Commute().SignOperator();
+   return this->map_local_operator(SimpleOperator(Operator), Operator.Commute(), Operator.description(), Cell, n);
+}
+
+UnitCell::operator_type
+UnitCell::map_local_operator(SimpleOperator const& Operator, LatticeCommute Commute, std::string Description, int Cell, int n) const
+{
+   std::string SignOperator = Commute.SignOperator();
 
    BasicFiniteMPO Result(Sites->size());
 
@@ -346,8 +352,7 @@ UnitCell::map_local_operator(SiteOperator const& Operator, int Cell, int n) cons
       Result[i](0,0) = I;
    }
 
-   return UnitCellMPO(Sites, Result, Operator.Commute(), Cell*this->size(),
-                      Operator.description());
+   return UnitCellMPO(Sites, Result, Commute, Cell*this->size(), Description);
 }
 
 UnitCell::operator_type

--- a/lattice/unitcell.h
+++ b/lattice/unitcell.h
@@ -186,6 +186,9 @@ class UnitCell
       // Lookup a local operator on a given unit cell index
       operator_type local_operator(std::string const& Op, int Cell, int Site) const;
 
+      // Given a SimpleOperator, and a JW string operator, map it into a UnitCellMPO at the given (Cell)[Site] coordinates
+      operator_type map_local_operator(SimpleOperator const& Op, LatticeCommute Commute, std::string Description, int Cell, int Site) const;
+
       // Given a SiteOperator, map it into a UnitCellMPO at the given (Cell)[Site] coordinates
       operator_type map_local_operator(SiteOperator const& Op, int Cell, int Site) const;
 

--- a/models/bosehubbard-2component-u1u1.cpp
+++ b/models/bosehubbard-2component-u1u1.cpp
@@ -1,0 +1,134 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://physics.uq.edu.au/people/ianmcc/mptoolkit/
+//
+// models/bosehubbard-2component-u1z2.cpp
+//
+// Copyright (C) 2015-2016 Ian McCulloch <ianmcc@physics.uq.edu.au>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Reseach publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#include "pheap/pheap.h"
+#include "lattice/infinitelattice.h"
+#include "lattice/unitcelloperator.h"
+#include "mp/copyright.h"
+#include "models/boson-2component-u1u1.h"
+#include "common/terminal.h"
+#include "common/prog_options.h"
+#include <boost/program_options.hpp>
+
+namespace prog_opt = boost::program_options;
+
+int main(int argc, char** argv)
+{
+   try
+   {
+      std::string FileName;
+      int MaxN = 5;
+
+      prog_opt::options_description desc("Allowed options", terminal::columns());
+      desc.add_options()
+         ("help", "show this help message")
+         ("NumBosons,N", prog_opt::value(&MaxN),
+          FormatDefault("Maximum number of bosons per site", MaxN).c_str())
+         ("out,o", prog_opt::value(&FileName), "output filename [required]")
+         ;
+
+      prog_opt::variables_map vm;
+      prog_opt::store(prog_opt::command_line_parser(argc, argv).
+                      options(desc).style(prog_opt::command_line_style::default_style ^
+                                          prog_opt::command_line_style::allow_guessing).
+                      run(), vm);
+      prog_opt::notify(vm);
+
+      OperatorDescriptions OpDescriptions;
+      OpDescriptions.set_description("Bosonic 2-leg ladder with U(1)xU(1) symmetry");
+      OpDescriptions.author("IP McCulloch", "ianmcc@physics.uq.edu.au");
+      OpDescriptions.add_operators()
+         ("H_JA"   , "nearest-neighbor hopping for the A-species")
+         ("H_JB"   , "nearest-neighbor hopping for the B-species")
+         ("H_UA"   , "Coulomb repulsion for species A")
+         ("H_UB"   , "Coulomb repulsion for species B")
+         ("H_U"    , "Intra-species coulomb repulsion, H_UA + H_UB")
+         ("H_UAB"  , "inter-species Coulomb repulsion")
+         ;
+
+      if (vm.count("help") || !vm.count("out"))
+      {
+         print_copyright(std::cerr);
+         std::cerr << "usage: " << basename(argv[0]) << " [options]\n";
+         std::cerr << desc << '\n';
+         std::cerr << OpDescriptions << 'n';
+         return 1;
+      }
+
+      LatticeSite Site = Boson2ComponentU1U1(MaxN);
+      UnitCell Cell = Site;
+      InfiniteLattice Lattice(&Cell);
+
+      UnitCellOperator BH_A(Cell, "BH_A"), B_A(Cell, "B_A"), N_A(Cell, "N_A"), N2_A(Cell, "N2_A"),
+         BH_B(Cell, "BH_B"), B_B(Cell, "B_B"), N_B(Cell, "N_B"), N2_B(Cell, "N2_B"), I(Cell, "I");
+
+      Lattice["H_JA"]   = -sum_unit(BH_A(0)*B_A(1) + B_A(0)*BH_A(1));
+      Lattice["H_JB"]   = -sum_unit(BH_B(0)*B_B(1) + B_B(0)*BH_B(1));
+      Lattice["H_UA"]   = 0.5*sum_unit(N_A(0)*(N_A(0)-I(0)));
+      Lattice["H_UB"]   = 0.5*sum_unit(N_B(0)*(N_B(0)-I(0)));
+      Lattice["H_U"]    = Lattice["H_UA"] + Lattice["H_UB"];
+      Lattice["H_UAB"]  = sum_unit(N_A(0)*N_B(0));
+
+      // Add projectors onto N+1 and N-1 bosons
+
+      UnitCellOperator NP(Cell, "NP"), NM(Cell, "NM");
+      LatticeSite NPSite = Boson2ComponentU1U1(MaxN+1);
+      LatticeSite NMSite = Boson2ComponentU1U1(MaxN-1);
+      SimpleOperator NPOp(NPSite.Basis1(), Site.Basis1());
+      SimpleOperator NMOp(NMSite.Basis1(), Site.Basis1());
+      for (int na = 0; na <= MaxN; ++na)
+      {
+         for (int nb = 0; nb <= MaxN; ++nb)
+         {
+            int n = na*(MaxN+1)+nb;
+            int np = na*(MaxN+2)+nb;
+            NPOp(np, n) = 1.0;
+            if (na < MaxN && nb < MaxN)
+            {
+               int nm = na*MaxN+nb;
+               NMOp(nm, n) = 1.0;
+            }
+         }
+      }
+      NP(0) = Cell.map_local_operator(NPOp, LatticeCommute::Bosonic, "Projector onto N+1 bosons", 0, 0);
+      NM(0) = Cell.map_local_operator(NMOp, LatticeCommute::Bosonic, "Projector onto N-1 bosons", 0, 0);
+
+      // Information about the lattice
+      Lattice.set_command_line(argc, argv);
+      Lattice.set_operator_descriptions(OpDescriptions);
+
+      // save the lattice to disk
+      pheap::ExportObject(FileName, Lattice);
+   }
+   catch (prog_opt::error& e)
+   {
+      std::cerr << "Exception while processing command line options: " << e.what() << '\n';
+      return 1;
+   }
+   catch (std::exception& e)
+   {
+      std::cerr << "Exception: " << e.what() << '\n';
+      return 1;
+   }
+   catch (...)
+   {
+      std::cerr << "Unknown exception!\n";
+      return 1;
+   }
+}

--- a/models/boson-2component-u1u1.h
+++ b/models/boson-2component-u1u1.h
@@ -43,78 +43,92 @@ std::string Coord(int i, int j)
    return S.str();
 }
 
-
 inline
-LatticeSite CreateBoseHubbard2BosonsU1U1Site(int MaxN, std::string const& Sym1 = "NA", std::string const& Sym2 = "NB")
+LatticeSite Boson2ComponentU1U1(int MaxN, std::string const& Sym1 = "NA", std::string const& Sym2 = "NB")
 {
    SymmetryList Symmetry(Sym1+":U(1),"+Sym2+":U(1)");
    QuantumNumbers::QNConstructor<QuantumNumbers::U1, QuantumNumbers::U1> QN(Symmetry);
    SiteBasis Basis(Symmetry);
    SiteOperator B_A, BH_A, N_A, N2_A;
-        SiteOperator B_B, BH_B, N_B, N2_B;
-        SiteOperator P, R, Q, I;
-   LatticeSite Site;
+   SiteOperator B_B, BH_B, N_B, N2_B;
+   SiteOperator P, R, Q, I;
+   LatticeSite Site("2-component bosons, maximum number of particles per site = " + boost::lexical_cast<std::string>(MaxN));
+
+   OperatorDescriptions OpDescriptions;
+   OpDescriptions.add_operators()
+      ("I"   , "identity")
+      ("R"   , "reflection (trivial)")
+      ("B_A" , "annihilation, species A")
+      ("BH_A", "creation, species A")
+      ("N_A" , "particle number, species A")
+      ("N2_A", "Coulomb repulstion N*(N-1), species A")
+      ("B_B" , "annihilation, species B")
+      ("BH_B", "creation, species B")
+      ("N_B" , "particle number, species B")
+      ("N2_B", "Coulomb repulstion N*(N-1), species B")
+
+      ;
 
    // Setup the site basis
    for (int n = 0; n <= MaxN; ++n)
    {
       for (int m = 0; m <= MaxN; ++m)
-                {
-                        std::string q = Coord(n,m);
-        Basis.push_back(q, QN(n, m));
-                }
+      {
+         std::string q = Coord(n,m);
+         Basis.push_back(q, QN(n, m));
+      }
    }
 
    BH_A = SiteOperator(Basis, QN(1, 0), LatticeCommute::Bosonic);
    for (int n = 0; n < MaxN; ++n)
-        {
-                for (int m = 0; m <= MaxN; ++m)
-        {
-                        std::string q1 = Coord(n+1,m);
-                        std::string q2 = Coord(n,m);
+   {
+      for (int m = 0; m <= MaxN; ++m)
+      {
+         std::string q1 = Coord(n+1,m);
+         std::string q2 = Coord(n,m);
 
-                        int l1 = BH_A.Basis1().LookupOrNeg(q1);
-                        int l2 = BH_A.Basis2().LookupOrNeg(q2);
+         int l1 = BH_A.Basis1().LookupOrNeg(q1);
+         int l2 = BH_A.Basis2().LookupOrNeg(q2);
 
-                        if (l1 >= 0 && l2 >= 0) {
-                                BH_A(q1, q2) = std::sqrt(double(n + 1));
-                        } else {
-                                std::cout << "A: " << n << " " << m << " " << q1 << " " << q2 << '\n';
-                        }
-                }
+         if (l1 >= 0 && l2 >= 0) {
+            BH_A(q1, q2) = std::sqrt(double(n + 1));
+         } else {
+            std::cout << "A: " << n << " " << m << " " << q1 << " " << q2 << '\n';
+         }
+      }
    }
 
-        BH_B = SiteOperator(Basis, QN(0, 1), LatticeCommute::Bosonic);
+   BH_B = SiteOperator(Basis, QN(0, 1), LatticeCommute::Bosonic);
    for (int n = 0; n <= MaxN; ++n)
-        {
-                for (int m = 0; m < MaxN; ++m)
-        {
-                std::string q1 = Coord(n,m+1);
-                        std::string q2 = Coord(n,m);
+   {
+      for (int m = 0; m < MaxN; ++m)
+      {
+         std::string q1 = Coord(n,m+1);
+         std::string q2 = Coord(n,m);
 
-                        int l1 = BH_B.Basis1().LookupOrNeg(q1);
-                        int l2 = BH_B.Basis2().LookupOrNeg(q2);
+         int l1 = BH_B.Basis1().LookupOrNeg(q1);
+         int l2 = BH_B.Basis2().LookupOrNeg(q2);
 
-                        if (l1 >= 0 && l2 >= 0) {
-                                BH_B(q1, q2) = std::sqrt(double(m + 1));
-                        } else {
-                                std::cout << "B: " << n << " " << m << " " << q1 << " " << q2 << '\n';
-                        }
-                }
+         if (l1 >= 0 && l2 >= 0) {
+            BH_B(q1, q2) = std::sqrt(double(m + 1));
+         } else {
+            std::cout << "B: " << n << " " << m << " " << q1 << " " << q2 << '\n';
+         }
+      }
    }
 
-        I = SiteOperator::Identity(Basis);
+   I = SiteOperator::Identity(Basis);
    Site["I"] = I;
    R = I;
    Site["R"] = R;
 
    Site["BH_A"] = BH_A;
-        Site["BH_B"] = BH_B;
+   Site["BH_B"] = BH_B;
 
    B_A = adjoint(BH_A);
    Site["B_A"] = B_A;
 
-        B_B = adjoint(BH_B);
+   B_B = adjoint(BH_B);
    Site["B_B"] = B_B;
 
    N_A = prod(BH_A, B_A, QN(0,0));
@@ -122,12 +136,12 @@ LatticeSite CreateBoseHubbard2BosonsU1U1Site(int MaxN, std::string const& Sym1 =
    N2_A = prod(N_A, N_A-I, QN(0,0));
    Site["N2_A"] = N2_A;
 
-        N_B = prod(BH_B, B_B, QN(0,0));
+   N_B = prod(BH_B, B_B, QN(0,0));
    Site["N_B"] = N_B;
    N2_B = prod(N_B, N_B-I, QN(0,0));
    Site["N2_B"] = N2_B;
 
-   DEBUG_TRACE(BH_A)(B_A)(I)(N_A)(N2_A)(BH_B)(B_B)(N_B)(N2_B);
+   Site.set_operator_descriptions(OpDescriptions);
 
    return Site;
 }

--- a/mp-algorithms/dmrg.cpp
+++ b/mp-algorithms/dmrg.cpp
@@ -613,7 +613,7 @@ TruncationInfo DMRG::TruncateAndShiftLeft(StatesInfo const& States)
    std::tie(U, Lambda) = SubspaceExpandBasis1(*C, *H, HamMatrices.right(), MixingInfo,
 					      KeepList, adjoint(QuantumNumbersInBasis(CNext->LocalBasis())),
 					      States, Info,
-					      HamMatrices.left(), UpdateKeepList);
+					      HamMatrices.left(), DoUpdateKeepList);
 
    if (Verbose > 1)
    {
@@ -651,7 +651,7 @@ TruncationInfo DMRG::TruncateAndShiftRight(StatesInfo const& States)
    std::tie(Lambda, U) = SubspaceExpandBasis2(*C, *H, HamMatrices.left(), MixingInfo,
 					      KeepList, QuantumNumbersInBasis(CNext->LocalBasis()),
 					      States, Info,
-					      HamMatrices.right(), UpdateKeepList);
+					      HamMatrices.right(), DoUpdateKeepList);
    if (Verbose > 1)
    {
       std::cerr << "Truncating right basis, states=" << Info.KeptStates() << '\n';

--- a/mp-algorithms/dmrg.cpp
+++ b/mp-algorithms/dmrg.cpp
@@ -41,7 +41,7 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
                      MixInfo const& Mix, KeepListType& KeepList,
 		     std::set<QuantumNumbers::QuantumNumber> const& AddedQN,
 		     StatesInfo const& States, TruncationInfo& Info,
-                     StateComponent const& LeftHam)
+                     StateComponent const& LeftHam, bool DoUpdateKeepList)
 {
    // truncate - FIXME: this is the s3e step
 #if defined(SSC)
@@ -96,14 +96,11 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
 
    std::list<EigenInfo> KeptStates(DM.begin(), DMPivot);
    std::list<EigenInfo> DiscardStates(DMPivot, DM.end());
+
    // Update the keep list.  It would perhaps be better to do this with respect
    // to the stage 2 density matrix, but easier to do it here
-   UpdateKeepList(KeepList,
-		  AddedQN,
-		  DM.Basis(),
-		  KeptStates,
-		  DiscardStates,
-		  Info);
+   if (DoUpdateKeepList)
+      UpdateKeepList(KeepList, AddedQN, DM.Basis(), KeptStates, DiscardStates, Info);
 
    MatrixOperator UKeep = DM.ConstructTruncator(KeptStates.begin(), KeptStates.end());
    Lambda = Lambda * herm(UKeep);
@@ -134,7 +131,7 @@ SubspaceExpandBasis2(StateComponent& C, OperatorComponent const& H, StateCompone
                      MixInfo const& Mix, KeepListType& KeepList,
 		     std::set<QuantumNumbers::QuantumNumber> const& AddedQN,
 		     StatesInfo const& States, TruncationInfo& Info,
-                     StateComponent const& RightHam)
+                     StateComponent const& RightHam, bool DoUpdateKeepList)
 {
    // truncate - FIXME: this is the s3e step
    MatrixOperator Lambda = ExpandBasis2(C);
@@ -174,12 +171,8 @@ SubspaceExpandBasis2(StateComponent& C, OperatorComponent const& H, StateCompone
    std::list<EigenInfo> DiscardStates(DMPivot, DM.end());
    // Update the keep list.  It would perhaps be better to do this with respect
    // to the stage 2 density matrix, but easier to do it here
-   UpdateKeepList(KeepList,
-		  AddedQN,
-		  DM.Basis(),
-		  KeptStates,
-		  DiscardStates,
-		  Info);
+   if (DoUpdateKeepList)
+      UpdateKeepList(KeepList, AddedQN, DM.Basis(), KeptStates, DiscardStates, Info);
 
    MatrixOperator UKeep = DM.ConstructTruncator(KeptStates.begin(), KeptStates.end());
 
@@ -194,8 +187,6 @@ SubspaceExpandBasis2(StateComponent& C, OperatorComponent const& H, StateCompone
 
    return std::make_pair(D, Vh);
 }
-
-
 
 PStream::opstream& operator<<(PStream::opstream& out, DMRG const& d)
 {
@@ -622,7 +613,7 @@ TruncationInfo DMRG::TruncateAndShiftLeft(StatesInfo const& States)
    std::tie(U, Lambda) = SubspaceExpandBasis1(*C, *H, HamMatrices.right(), MixingInfo,
 					      KeepList, adjoint(QuantumNumbersInBasis(CNext->LocalBasis())),
 					      States, Info,
-					      HamMatrices.left());
+					      HamMatrices.left(), UpdateKeepList);
 
    if (Verbose > 1)
    {
@@ -660,7 +651,7 @@ TruncationInfo DMRG::TruncateAndShiftRight(StatesInfo const& States)
    std::tie(Lambda, U) = SubspaceExpandBasis2(*C, *H, HamMatrices.left(), MixingInfo,
 					      KeepList, QuantumNumbersInBasis(CNext->LocalBasis()),
 					      States, Info,
-					      HamMatrices.right());
+					      HamMatrices.right(), UpdateKeepList);
    if (Verbose > 1)
    {
       std::cerr << "Truncating right basis, states=" << Info.KeptStates() << '\n';

--- a/mp-algorithms/dmrg.h
+++ b/mp-algorithms/dmrg.h
@@ -47,22 +47,22 @@ class DMRG
       // Adds x to the 'orthogonal set', that we explicitly orthogonalize the
       // wavefunction against
       void AddOrthogonalState(FiniteWavefunctionLeft x);
-      
+
       void StartSweep(bool IncrementSweepNumber = true, double Broad = 0);
-      
+
       void EndSweep();    // statistics for end of sweep
-      
+
       void StartIteration();  // prepare statistics for start of iteration
       void EndIteration();    // statistics for end of iteration
-      
+
       void CreateLogFiles(std::string const& BasePath, ConfList const& Conf);
       void RestoreLogFiles(std::string const& BasePath, ConfList const& Conf);
-      
+
       //   int LeftSize() const { return Psi.LeftSize(); }
       //   int RightSize() const { return Psi.RightSize(); }
-      
+
       LocalEigensolver& Solver() { return Solver_; }
-      
+
       // Invoke the local eigensolver
       std::complex<double> Solve();
 
@@ -122,7 +122,7 @@ class DMRG
       double SweepTruncatedEnergy;   // sum of (E_0 - E_truncated) over the sweep
       double SweepEnergyError;       // standard error of the energy at each iteration
       double SweepLastMixFactor;     // the last used mix factor, for the .sweep log file
-      
+
       // some statistics, for current iteration
       int IterationNumMultiplies;
       int IterationNumStates;
@@ -148,6 +148,7 @@ class DMRG
       bool NormalizeWavefunction; // should we normalize the wavefunction after each truncation?
       bool MixUseEnvironment;
       bool UseDGKS;  // use DGKS correction in the lanczos for orthogonal states
+      bool DoUpdateKeepList; // set to true to use the KeepList to ensure quantum number subspaces are represented
       LocalEigensolver Solver_;
       int Verbose;
 

--- a/mp/mp-change-lattice.cpp
+++ b/mp/mp-change-lattice.cpp
@@ -1,0 +1,214 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://physics.uq.edu.au/people/ianmcc/mptoolkit/
+//
+// mp/mp-change-lattice.cpp
+//
+// Copyright (C) 2015-2023 Ian McCulloch <ianmcc@physics.uq.edu.au>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Reseach publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#include "mp/copyright.h"
+#include "wavefunction/mpwavefunction.h"
+#include "common/environment.h"
+#include "common/terminal.h"
+#include "common/prog_options.h"
+#include "common/prog_opt_accum.h"
+#include "common/environment.h"
+#include "interface/inittemp.h"
+#include "tensor/tensor_eigen.h"
+#include "lattice/infinitelattice.h"
+#include "lattice/unitcell-parser.h"
+#include "common/statistics.h"
+
+namespace prog_opt = boost::program_options;
+
+
+int main(int argc, char** argv)
+{
+   try
+   {
+      int Verbose = 0;
+      std::string Lat1Str;
+      std::string Lat2Str;
+      std::string InputFile;
+      std::string OutputFile;
+      bool Force = false;
+      bool AssumeOrthogonal = false;
+
+      prog_opt::options_description desc("Allowed options", terminal::columns());
+      desc.add_options()
+         ("help", "show this help message")
+         ("force,f", prog_opt::bool_switch(&Force),
+          "allow overwriting the output file, if it already exists")
+         ("verbose,v",  prog_opt_ext::accum_value(&Verbose),
+          "extra debug output [can be used multiple times]")
+         ;
+
+      prog_opt::options_description hidden("Hidden options");
+      hidden.add_options()
+         ("lat1", prog_opt::value(&Lat1Str), "lat1")
+         ("lat2", prog_opt::value(&Lat2Str), "lat2")
+         ("psi1", prog_opt::value(&InputFile), "psi1")
+         ("psi2", prog_opt::value(&OutputFile), "psi2")
+         ;
+
+      prog_opt::positional_options_description p;
+      p.add("lat1", 1);
+      p.add("lat2", 1);
+      p.add("psi1", 1);
+      p.add("psi2", 1);
+
+      prog_opt::options_description opt;
+      opt.add(desc).add(hidden);
+
+      prog_opt::variables_map vm;
+      prog_opt::store(prog_opt::command_line_parser(argc, argv).
+                      options(opt).positional(p).run(), vm);
+      prog_opt::notify(vm);
+
+      if (vm.count("help") > 0 || vm.count("psi2") < 1)
+      {
+         print_copyright(std::cerr, "tools", basename(argv[0]));
+         std::cerr << "usage: " << basename(argv[0]) << " [options] <current_lattice> <new_lattice> <input-psi> <output-psi>\n";
+         std::cerr << desc << '\n';
+         std::cerr << "This tool changes the local Hilbert space of an MPS to a new lattice.\n"
+                   << "It does this by matching the state names in the local Hilbert space to the new lattice.\n"
+                   << "A typical use for this is for Bosonic models, to adjust the maximum number of bosons per site,\n"
+                   << "but it can also be used to effect a Gutzwiller projection, or similar projections.\n"
+                   << "If there are some states in the current Hilbert space that are not present in the new lattice, then\n"
+                   << "those states are projected out, leaving the wavefunction with reduced norm.\n"
+                   << "If there are states in the new lattice that are not in the current Hilbert space, they are set to zero.\n";
+         return 1;
+      }
+
+      std::cout.precision(getenv_or_default("MP_PRECISION", 14));
+      std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
+
+      if (Verbose > 0)
+         std::cout << "Loading wavefunction..." << std::endl;
+
+      pvalue_ptr<MPWavefunction> PsiPtr;
+      if (InputFile == OutputFile)
+         PsiPtr = pheap::OpenPersistent(InputFile.c_str(), mp_pheap::CacheSize());
+      else
+      {
+         pheap::Initialize(OutputFile, 1, mp_pheap::PageSize(), mp_pheap::CacheSize(), false, Force);
+         PsiPtr = pheap::ImportHeap(InputFile);
+      }
+
+      FiniteWavefunctionLeft Psi = PsiPtr->get<FiniteWavefunctionLeft>();
+
+      pvalue_ptr<InfiniteLattice> Lattice1Ptr = pheap::ImportHeap(Lat1Str);
+      InfiniteLattice Lattice1 = *Lattice1Ptr;
+
+      pvalue_ptr<InfiniteLattice> Lattice2Ptr = pheap::ImportHeap(Lat2Str);
+      InfiniteLattice Lattice2 = *Lattice2Ptr;
+
+      if (Verbose > 0)
+         std::cout << "Mapping wavefunction" << std::flush;
+      if (Verbose > 1)
+         std::cout << std::endl;
+      std::list<StateComponent> NewPsi;
+      UnitCell::const_iterator CurrentSite = Lattice1.GetUnitCell().begin();
+      UnitCell::const_iterator NewSite = Lattice2.GetUnitCell().begin();
+      int s = 0;
+      for (auto I = Psi.begin(); I != Psi.end(); ++I)
+      {
+         if (Verbose == 1)
+         {
+            std::cout << '.';
+         }
+         if (Verbose > 1)
+         {
+            std::cout << "Mapping wavefunction site " << s << std::endl;
+         }
+         if (Verbose > 2)
+         {
+            std::cout << "Current Hilbert space dimension: " << (CurrentSite->Basis().size()) << std::endl;
+            std::cout << "New Hilbert space dimension: " << (NewSite->Basis().size()) << std::endl;
+         }
+         int c = 0; // count of the number of states that we've mapped into the new basis
+         StateComponent A(NewSite->Basis(), I->Basis1(), I->Basis2());
+         for (int i = 0; i < NewSite->Basis().size(); ++i)
+         {
+            std::string Label = NewSite->Basis().Label(i);
+            int j = CurrentSite->Basis().LookupOrNeg(Label);
+            if (j >= 0)
+            {
+               if (Verbose > 3)
+               {
+                  std::cout << "Mapping state " << Label << " into the new basis." << std::endl;
+               }
+               ++c;
+               A[i] = (*I)[j];
+            }
+            else if (Verbose > 3)
+            {
+               std::cout << "New basis state " << Label << " does not exist in the current basis; will be set to zero." << std::endl;
+            }
+         }
+         if (c == 0)
+         {
+            std::cout << "mp-change-lattice: fatal: new lattice at site " << s << " has no states in common in the local Hilbert spaces!\n";
+            exit(1);
+         }
+         if (Verbose > 2)
+         {
+            std::cout << "Mapped " << c << " basis states." << std::endl;
+         }
+         ++s;
+         if (++CurrentSite == Lattice1.GetUnitCell().end())
+            CurrentSite = Lattice1.GetUnitCell().begin();
+         if (++NewSite == Lattice2.GetUnitCell().end())
+         {
+            NewSite = Lattice2.GetUnitCell().begin();
+         }
+         NewPsi.push_back(std::move(A));
+      }
+      if (Verbose == 1)
+         std::cout << std::endl;
+      if (Verbose > 0)
+      {
+         std::cout << "Finished mapping wavefunction." << std::endl;
+         std::cout << "Orthogonalizing wavefunction..." << std::endl;
+      }
+
+      PsiPtr.mutate()->Wavefunction() = FiniteWavefunctionLeft::Construct(LinearWavefunction::FromContainer(NewPsi.begin(), NewPsi.end()));
+
+      PsiPtr.mutate()->AppendHistoryCommand(EscapeCommandline(argc, argv));
+      PsiPtr.mutate()->SetDefaultAttributes();
+
+      if (Verbose > 0)
+         std::cout << "Finished." << std::endl;
+
+      pheap::ShutdownPersistent(PsiPtr);
+   }
+   catch (prog_opt::error& e)
+   {
+      std::cerr << "Exception while processing command line options: " << e.what() << '\n';
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (std::exception& e)
+   {
+      std::cerr << "Exception: " << e.what() << '\n';
+      pheap::Cleanup();
+      return 1;
+   }
+   catch (...)
+   {
+      std::cerr << "Unknown exception!\n";
+      pheap::Cleanup();
+      return 1;
+   }
+}

--- a/mp/mp-dmrg.cpp
+++ b/mp/mp-dmrg.cpp
@@ -125,6 +125,7 @@ int main(int argc, char** argv)
       double MinTol = 1E-16; // lower bound for the eigensolver tolerance - seems we dont really need it
       std::string States = "100";
       double EvolveDelta = 0.0;
+      bool NoKeepList = false;
 
       std::cout.precision(14);
 
@@ -164,6 +165,7 @@ int main(int argc, char** argv)
          ("orthogonal", prog_opt::value<std::vector<std::string> >(),
           "force the wavefunction to be orthogonal to this state ***NOT YET IMPLEMENTED***")
          ("dgks", prog_opt::bool_switch(&UseDGKS), "Use DGKS correction for the orthogonality vectors")
+         ("no-keep-list", prog_opt::bool_switch(&NoKeepList), "Don't use the KeepList for quantum number subspaces")
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),
 	  "For the shift-invert and shift-invert-direct solver, the target energy")
 	 ("subspacesize", prog_opt::value(&SubspaceSize),
@@ -230,6 +232,7 @@ int main(int argc, char** argv)
       DMRG dmrg(Psi, HamMPO, Verbose);
 
       dmrg.UseDGKS = UseDGKS;
+      dmrg.DoUpdateKeepList = !NoKeepList;
       dmrg.Solver().SetSolver(Solver);
 
       dmrg.Solver().MaxTol = MaxTol;

--- a/mpo/operator_utilities.cpp
+++ b/mpo/operator_utilities.cpp
@@ -110,7 +110,8 @@ SimpleOperator ProjectBasis(BasisList const& b, QuantumNumbers::QuantumNumber co
 
 std::complex<double> PropIdent(SimpleOperator const& X, double UnityEpsilon)
 {
-   DEBUG_PRECONDITION_EQUAL(X.Basis1(), X.Basis2());
+   if (X.Basis1() != X.Basis2())
+      return 0.0;
    SimpleOperator Ident = SimpleOperator::make_identity(X.Basis1());
    std::complex<double> x = inner_prod(Ident, X) / double(X.Basis1().total_degree());
    if (norm_frob_sq(X-x*Ident) > UnityEpsilon*UnityEpsilon)


### PR DESCRIPTION
Operators that change the local Hilbert space need some additional thought and design work.   Operators, including MPO's, are allowed to change the local Hibert space.  The intention behind this is to allow operators to map between different Hilbert spaces, eg to change the boson number cutoff, also Gutzwiller projectors between fermions and spins, and other examples such as swap and translation operators on non-homogeneous lattices.  This needs a bit more thought however, because currently when we create an MPO from a local operator, it gets identity operators on all other sites except the active site, which means it isn't possible to construct operators such as projection operators that act on more than 1 site (or in some cases we can, but we need to be strict about the order of operations).

A lot of this will be simplified once we can eliminate JW strings, because that allows the possibility to have MPO's that
have support over a sparse (and disjoint) set of sites.  These MPO's could be multiplied together, and the Hilbert spaces only need to match on the sites that have non-trivial support.  But for the time being it isn't really possible to make this kind of operator.  As a work-around, which will probably still be useful once we can do more general projections, there is a tool mp-change-lattice, which maps the local Hilbert space of one lattice to another.  The main use for this is to change the boson number cutoff for bosonic models, but it has other potential uses too.

There are some miscellaneous changes that facilitate MPO's with Basis1() != Basis2(), which are harmess but not actually used by the mp-change-lattice tool.

This commit also adds the --no-keep-list option to mp-dmrg.  This is needed to fix the number of states at exactly m, if that is desired.