### PR TITLE
Gmres improvements

### DIFF
--- a/mp-algorithms/gmres.h
+++ b/mp-algorithms/gmres.h
@@ -17,27 +17,9 @@
 // the file CITATIONS in the main source directory.
 //----------------------------------------------------------------------------
 // ENDHEADER
-//
-//*****************************************************************
-// Iterative template routine -- GMRES
-//
-// GMRES solves the unsymmetric linear system Ax = b using the
-// Generalized Minimum Residual method
-//
-// GMRES follows the algorithm described on p. 20 of the
-// SIAM Templates book.
-//
-// The return value indicates convergence within max_iter (input)
-// iterations (0), or no onvergence within max_iter iterations (1).
-//
-// Upon successful return, output arguments have the following values:
-//
-//        x  --  approximate solution to Ax = b
-// max_iter  --  the number of iterations performed before the
-//               tolerance was reached
-//      tol  --  the residual after the final iteration
-//
-//*****************************************************************
+
+// GMRES solver, with iterative refinement
+// Adapted from the Templates book
 
 #if !defined(MPTOOLKIT_MP_ALGORITHMS_GMRES_H)
 #define MPTOOLKIT_MP_ALGORITHMS_GMRES_H

--- a/mp-algorithms/gmres.h
+++ b/mp-algorithms/gmres.h
@@ -134,6 +134,9 @@ void ApplyPlaneRotation(std::tuple<Real, Scalar> const& R, Scalar &dx, Scalar &d
 // On exit: tol = residual norm
 // iter = number of iterations performed (added to the existing value)
 // return value is 0
+//
+// normb is a scaling factor for the residual norm calculation.  In principle this should be set to
+// the norm of the right hand side, multiplied by the condition number.
 
 template <typename Vector, typename MultiplyFunc, typename Preconditioner>
 int
@@ -339,14 +342,13 @@ GmResRefine(Vector &x, MultiplyFunc MatVecMultiply, Vector const& b,
 
 template <typename Vector, typename MultiplyFunc, typename Preconditioner>
 int
-GmResRefineOrtho(Vector &x, Vector const& OrthoLeft, Vector const& OrthoRight, MultiplyFunc MatVecMultiply, Vector const& b,
-      int m, int& max_iter, double& tol, Preconditioner P, int Verbose = 0)
+GmResRefineOrtho(Vector &x, Vector const& OrthoLeft, Vector const& OrthoRight, MultiplyFunc MatVecMultiply, double cond, Vector const& b, int m, int& max_iter, double& tol, Preconditioner P, int Verbose = 0)
 {
    // Assume the initial vector isn't good, so do one round of GMRES before iterative refinement
    // We can force this simply by setting the initial vector x to zero
    double OriginalTol = tol;
    int Iter = 0;
-   double normb = norm_frob(b);
+   double normb = norm_frob(b) * cond;
 
    x *= 0.0;
    Vector xRefine = x;

--- a/mp-algorithms/triangular_mpo_solver.cpp
+++ b/mp-algorithms/triangular_mpo_solver.cpp
@@ -32,6 +32,19 @@ SolveMPO_Left(std::vector<KMatrixPolyType>& EMatK,
               int Degree, double Tol,
               double UnityEpsilon, int Verbose)
 {
+   SolveMPO_Left(EMatK, Psi, QShift, Op, LeftIdentity, RightIdentity, DefaultTCond, NeedFinalMatrix, Degree, Tol, UnityEpsilon, Verbose);
+}
+
+void
+SolveMPO_Left(std::vector<KMatrixPolyType>& EMatK,
+              LinearWavefunction const& Psi, QuantumNumber const& QShift,
+              BasicTriangularMPO const& Op,
+              //std::vector<MatrixOperator> BoundaryE,
+              MatrixOperator const& LeftIdentity,
+              MatrixOperator const& RightIdentity, double TCond, bool NeedFinalMatrix,
+              int Degree, double Tol,
+              double UnityEpsilon, int Verbose)
+{
    CHECK_EQUAL(RightIdentity.Basis1(), Psi.Basis1());
    CHECK_EQUAL(RightIdentity.Basis2(), Psi.Basis1());
    CHECK_EQUAL(LeftIdentity.Basis1(), Psi.Basis1());
@@ -259,7 +272,7 @@ SolveMPO_Left(std::vector<KMatrixPolyType>& EMatK,
             if (Verbose > 0)
                std::cerr << "Decomposing parts perpendicular to the unit matrix\n";
             E = DecomposePerpendicularPartsLeft(C, Diag, UnitMatrixLeft, UnitMatrixRight,
-                                            Psi, Psi, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                            Psi, Psi, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
          {

--- a/mp-algorithms/triangular_mpo_solver.h
+++ b/mp-algorithms/triangular_mpo_solver.h
@@ -47,6 +47,14 @@ double const DefaultEigenUnityEpsilon = 1E-12;
 // default tolerance for eigensolver and linear solver.  This is also a bit small in some cases.
 double const DefaultTol = 1E-14;
 
+// To get a proper stopping criteria, the GMRES needs the condition number of (1-T) operator. We can get a good estimate of
+// this condition number of we know the correlation length (i.e. the next leading eigenvalue of T).  We can assume that the
+// smallest eigenvalue of T will be ~ 0, so the largest magnitude eigenvalue of (1-T) will be ~1. So hence the condition number
+// is <= 1 / smallest_evalue_of(1-T), which is 1 / 1-|lambda_1|, which is approximately the correlation length.
+// Note that this is only a bound on the condition number, since lambda_1 may be complex and not near 1.0, even if it has
+// a magnitude near 1.0.
+double const DefaultTCond = 1E5;
+
 // Solve an MPO in the left-handed sense, as x_L * Op = lambda * x_L
 // We currently assume there is only one eigenvalue 1 of the transfer operator.
 // The LeftIdentity and RightIdentity are the right and left eigenmatrices of the
@@ -74,6 +82,15 @@ void
 SolveMPO_Left(std::vector<KMatrixPolyType>& EMatK,
               LinearWavefunction const& Psi, QuantumNumber const& QShift,
               BasicTriangularMPO const& Op, MatrixOperator const& Identity,
+              MatrixOperator const& Rho, double TCond,
+              bool NeedFinalMatrix, int Degree = 0, double Tol = DefaultTol,
+              double EigenUnityEpsilon = DefaultEigenUnityEpsilon, int Verbose = 0);
+
+// This version uses a default value for the condition numner
+void
+SolveMPO_Left(std::vector<KMatrixPolyType>& EMatK,
+              LinearWavefunction const& Psi, QuantumNumber const& QShift,
+              BasicTriangularMPO const& Op, MatrixOperator const& Identity,
               MatrixOperator const& Rho,
               bool NeedFinalMatrix, int Degree = 0, double Tol = DefaultTol,
               double EigenUnityEpsilon = DefaultEigenUnityEpsilon, int Verbose = 0);
@@ -86,7 +103,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
                     LinearWavefunction const& Psi1, LinearWavefunction const& Psi2, QuantumNumber const& QShift,
                     BasicTriangularMPO const& Op, MatrixOperator const& Identity,
                     MatrixOperator const& Rho,
-                    std::complex<double> lambda,
+                    double TCond,
                     bool NeedFinalMatrix, int Degree = 0, double Tol = DefaultTol,
                     double EigenUnityEpsilon = DefaultEigenUnityEpsilon, int Verbose = 0);
 
@@ -100,7 +117,7 @@ SolveSimpleMPO_Left(std::vector<MatrixPolyType>& EMat,
                    LinearWavefunction const& Psi, QuantumNumber const& QShift,
                    BasicTriangularMPO const& Op,
                    MatrixOperator const& Identity,
-                   MatrixOperator const& Rho, bool NeedFinalMatrix,
+                   MatrixOperator const& Rho, double TCond, bool NeedFinalMatrix,
                    int Degree, double Tol,
                    double UnityEpsilon, int Verbose);
 
@@ -109,7 +126,7 @@ SolveSimpleMPO_Right(std::vector<MatrixPolyType>& FMat,
                    LinearWavefunction const& Psi, QuantumNumber const& QShift,
                    BasicTriangularMPO const& Op,
                    MatrixOperator const& Identity,
-                   MatrixOperator const& Rho, bool NeedFinalMatrix,
+                   MatrixOperator const& Rho, double TCond, bool NeedFinalMatrix,
                    int Degree, double Tol,
                    double UnityEpsilon, int Verbose);
 

--- a/mp-algorithms/triangular_mpo_solver_cross.cpp
+++ b/mp-algorithms/triangular_mpo_solver_cross.cpp
@@ -26,7 +26,7 @@ void
 SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
                     LinearWavefunction const& Psi1, LinearWavefunction const& Psi2, QuantumNumber const& QShift,
                     BasicTriangularMPO const& Op, MatrixOperator const& LeftIdentity,
-                    MatrixOperator const& RightIdentity, std::complex<double> lambda, bool NeedFinalMatrix,
+                    MatrixOperator const& RightIdentity, double TCond, bool NeedFinalMatrix,
                     int Degree, double Tol,
                     double UnityEpsilon, int Verbose)
 {
@@ -36,11 +36,6 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
    CHECK_EQUAL(LeftIdentity.Basis2(), Psi2.Basis1());
 
    DEBUG_TRACE(Verbose)(Degree)(Tol);
-
-   // lambda is the leading eigenvalue of the transfer matrix.  We solve the MPO with respect to
-   // <Psi1|Op|Psi2> / <Psi1|Psi2>.  This amounts to dividing through by lambda every time we contract over a unit cell.
-   // Or equivalently, scale everything by Scale ( = 1 / lambda).
-   std::complex<double> Scale = 1.0 / lambda;
 
    int Dim = Op.Basis1().size();       // dimension of the MPO
    EMatK.reserve(Dim);
@@ -88,6 +83,19 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
    while (int(EMatK.size()) < Dim)
       EMatK.push_back(KMatrixPolyType());
 
+   // If the condition number is too big, then the result is numerically zero
+   if (TCond > 1E30)
+   {
+      if (Verbose > 0)
+      {
+         std::cerr << "Condition number is too large, result is identically zero.\n";
+      }
+      // Set the component of the polynomial to the zero matrix, so we can get some sensible output
+      EMatK.back()[1.0] = MatrixPolyType();
+      EMatK.back()[1.0][std::max(Degree,1)] = MatrixOperator(LeftIdentity.Basis1(), LeftIdentity.Basis2(), LeftIdentity.TransformsAs());
+      return;
+   }
+
    // solve recursively column 1 onwards
    for (int Col = StartCol; Col < Dim; ++Col)
    {
@@ -98,7 +106,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
 
       // Generate the next C matrices, C(n) = sum_{j<Col} Op(j,Col) E_j(n)
       KMatrixPolyType C = inject_left_mask(EMatK, Psi1, QShift, Op.data(), Psi2, mask_column(Op, Col))[Col];
-      ScalePoly(C, Scale);
+      //ScalePoly(C, Scale);
 
       // Now do the classification, based on the properties of the diagonal operator
       BasicFiniteMPO Diag = Op(Col, Col);
@@ -162,7 +170,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
             //UnitMatrixLeft *= 1.0 / norm_frob(UnitMatrixLeft);
             //       UnitMatrixLeft *= 2.0; // adding this brings in spurious components
             std::complex<double> EtaL = FindClosestUnitEigenvalue(UnitMatrixLeft,
-                                                                  InjectLeftQShift(Psi1, QShift, Diag, Psi2, Scale),
+                                                                  InjectLeftQShift(Psi1, QShift, Diag, Psi2, 1.0),
                                                                   Tol, Verbose);
             //UnitMatrixLeft *= lnorm;
             EtaL = std::conj(EtaL); // left eigenvalue, so conjugate (see comment at operator_actions.h)
@@ -183,7 +191,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
                double ddd = norm_frob(UnitMatrixRight);
                //UnitMatrixRight *= 1.0 / ddd; //norm_frob(UnitMatrixRight);
                std::complex<double> EtaR = FindClosestUnitEigenvalue(UnitMatrixRight,
-                                                                     InjectRightQShift(Psi1, QShift, Diag, Psi2, Scale),
+                                                                     InjectRightQShift(Psi1, QShift, Diag, Psi2, 1.0),
                                                                      Tol, Verbose);
                if (Verbose > 0)
                   std::cerr << "Right eigenvalue is " << EtaR << std::endl;
@@ -259,7 +267,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
             if (Verbose > 0)
                std::cerr << "Decomposing parts perpendicular to the unit matrix\n";
             E = DecomposePerpendicularPartsLeft(C, Diag, UnitMatrixLeft, UnitMatrixRight,
-                                            Psi1, Psi2, QShift, Scale, HasEigenvalue1, Tol, Verbose);
+                                            Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
          {

--- a/mp-algorithms/triangular_mpo_solver_cross.cpp
+++ b/mp-algorithms/triangular_mpo_solver_cross.cpp
@@ -84,7 +84,7 @@ SolveMPO_Left_Cross(std::vector<KMatrixPolyType>& EMatK,
       EMatK.push_back(KMatrixPolyType());
 
    // If the condition number is too big, then the result is numerically zero
-   if (TCond > 1E30)
+   if (TCond > 1E16)
    {
       if (Verbose > 0)
       {

--- a/mp-algorithms/triangular_mpo_solver_ea.cpp
+++ b/mp-algorithms/triangular_mpo_solver_ea.cpp
@@ -29,6 +29,7 @@ SolveMPO_EA_Left(std::vector<KMatrixPolyType>& EMatK, std::vector<KMatrixPolyTyp
                  std::complex<double> ExpIK, int Degree, double Tol, double UnityEpsilon,
                  bool NeedFinalMatrix, bool EAOptimization, int Verbose)
 {
+   double TCond = DefaultTCond;
    int Dim = Op.Basis1().size();
    int StartCol = EMatK.size();
    EMatK.resize(Dim);
@@ -142,11 +143,11 @@ SolveMPO_EA_Left(std::vector<KMatrixPolyType>& EMatK, std::vector<KMatrixPolyTyp
                C[1.0].erase(1);
                // For the EA algorithm, we only need the zero momentum components for the final column.
                E[1.0] = DecomposePerpendicularPartsLeft(C[1.0], 1.0, ExpIK*Diag, TransferEVLeft, TransferEVRight,
-                                                        Psi1, Psi2, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                        Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
             }
             else
                E = DecomposePerpendicularPartsLeft(C, ExpIK*Diag, TransferEVLeft, TransferEVRight,
-                                                   Psi1, Psi2, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                   Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
             std::cerr << "Skipping parts perpendicular to the unit matrix for the last column" << std::endl;
@@ -175,6 +176,7 @@ SolveMPO_EA_Right(std::vector<KMatrixPolyType>& FMatK, std::vector<KMatrixPolyTy
                   std::complex<double> ExpIK, int Degree, double Tol, double UnityEpsilon,
                   bool NeedFinalMatrix, bool EAOptimization, int Verbose)
 {
+   double TCond = DefaultTCond;
    int Dim = Op.Basis1().size();
    int StartRow = Dim-1-FMatK.size();
    CHECK(StartRow >= -1);
@@ -290,11 +292,11 @@ SolveMPO_EA_Right(std::vector<KMatrixPolyType>& FMatK, std::vector<KMatrixPolyTy
                C[1.0].erase(1);
                // For the EA algorithm, we only need the zero momentum components for the first row.
                F[1.0] = DecomposePerpendicularPartsRight(C[1.0], 1.0, std::conj(ExpIK)*Diag, TransferEVRight, TransferEVLeft,
-                                                         Psi1, Psi2, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                         Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
             }
             else
                F = DecomposePerpendicularPartsRight(C, std::conj(ExpIK)*Diag, TransferEVRight, TransferEVLeft,
-                                                    Psi1, Psi2, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                    Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
             std::cerr << "Skipping parts perpendicular to the unit matrix for the last row" << std::endl;
@@ -325,6 +327,8 @@ SolveMPO_EA_Left(std::vector<KMatrixPolyType>& EMatK, std::vector<KMatrixPolyTyp
 {
    PRECONDITION(Op.is_string());
 
+   double TCond = DefaultTCond;
+
    // If EMatK is nonempty, we must already have the result, so we can return early.
    if (!EMatK.empty())
       return;
@@ -346,7 +350,7 @@ SolveMPO_EA_Left(std::vector<KMatrixPolyType>& EMatK, std::vector<KMatrixPolyTyp
       std::cerr << "Decomposing parts perpendicular to the unit matrix" << std::endl;
 
    KMatrixPolyType E = DecomposePerpendicularPartsLeft(C, ExpIK*BasicFiniteMPO(Op), TLeft, TRight,
-                                                       Psi1, Psi2, QShift, 1.0, true, Tol, Verbose);
+                                                       Psi1, Psi2, QShift, TCond, true, Tol, Verbose);
 
    // Reinsert the components parallel to the unit matrix (if any).
    for (KComplexPolyType::const_iterator I = EParallel.begin(); I != EParallel.end(); ++I)
@@ -371,6 +375,8 @@ SolveMPO_EA_Right(std::vector<KMatrixPolyType>& FMatK, std::vector<KMatrixPolyTy
 {
    PRECONDITION(Op.is_string());
 
+   double TCond = DefaultTCond;
+
    // If FMatK is nonempty, we must already have the result, so we can return early.
    if (!FMatK.empty())
       return;
@@ -392,7 +398,7 @@ SolveMPO_EA_Right(std::vector<KMatrixPolyType>& FMatK, std::vector<KMatrixPolyTy
       std::cerr << "Decomposing parts perpendicular to the unit matrix" << std::endl;
 
    KMatrixPolyType F = DecomposePerpendicularPartsRight(C, std::conj(ExpIK)*BasicFiniteMPO(Op), TRight, TLeft,
-                                                        Psi1, Psi2, QShift, 1.0, true, Tol, Verbose);
+                                                        Psi1, Psi2, QShift, TCond, true, Tol, Verbose);
 
    // Reinsert the components parallel to the unit matrix (if any).
    for (KComplexPolyType::const_iterator I = FParallel.begin(); I != FParallel.end(); ++I)

--- a/mp-algorithms/triangular_mpo_solver_helpers.cpp
+++ b/mp-algorithms/triangular_mpo_solver_helpers.cpp
@@ -179,7 +179,7 @@ DecomposePerpendicularPartsLeft(MatrixPolyType const& C, std::complex<double> K,
                            LinearWavefunction const& Psi1,
                            LinearWavefunction const& Psi2,
                            QuantumNumber const& QShift,
-                           std::complex<double> Scale,
+                           double TCond,
                            bool HasEigenvalue1,
                            double Tol,
                            int Verbose)
@@ -218,6 +218,11 @@ DecomposePerpendicularPartsLeft(MatrixPolyType const& C, std::complex<double> K,
       RhsNorm2 = RhsNorm2 / (Rhs.Basis1().total_degree()*Rhs.Basis2().total_degree());
       //DEBUG_TRACE(RhsNorm2);
 
+      if (Verbose > 2)
+      {
+         std::cerr << "Orthogonality of perpendicular part, RhsNorm2=" << RhsNorm2 << '\n';
+      }
+
       if (RhsNorm2 > 0.0)
       {
          // Initial guess vector -- scale it by the norm of Rhs, improves the stability
@@ -231,8 +236,8 @@ DecomposePerpendicularPartsLeft(MatrixPolyType const& C, std::complex<double> K,
          }
 
          LinearSolveOrtho(E[m], Rho, Identity, OneMinusTransferLeft_Ortho(Psi1, QShift, K*Diag, Psi2,
-                     Identity, Rho, Scale, HasEigenvalue1),
-                     Rhs, Tol, Verbose);
+                     Identity, Rho, HasEigenvalue1),
+                     TCond, Rhs, Tol, Verbose);
 
          // do another orthogonalization -- this should be unncessary but for the paranoid...
          if (HasEigenvalue1 && E[m].TransformsAs() == Rho.TransformsAs())
@@ -242,7 +247,7 @@ DecomposePerpendicularPartsLeft(MatrixPolyType const& C, std::complex<double> K,
             z = inner_prod(E[m], Rho);
             if (Verbose > 2)
             {
-               std::cerr << "Orthogonality of perpendicular part, RhsNorm2=" << RhsNorm2 << ", z=" << norm_frob_sq(z) << '\n';
+               std::cerr << "z=" << norm_frob_sq(z) << '\n';
             }
             if (LinearAlgebra::norm_frob_sq(z) > Tol * RhsNorm2)
             {
@@ -268,7 +273,7 @@ DecomposePerpendicularPartsLeft(KMatrixPolyType const& C,
                             LinearWavefunction const& Psi1,
                             LinearWavefunction const& Psi2,
                             QuantumNumber const& QShift,
-                            std::complex<double> Scale,
+                            double TCond,
                             bool HasEigenvalue1,
                             double Tol,
                             int Verbose)
@@ -280,7 +285,7 @@ DecomposePerpendicularPartsLeft(KMatrixPolyType const& C,
    {
       std::complex<double> K = I->first;  // the momentum (complex phase)
       E[K] = DecomposePerpendicularPartsLeft(I->second, I->first, Diag, Identity, Rho,
-                  Psi1, Psi2, QShift, Scale, HasEigenvalue1, Tol, Verbose);
+                  Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
    }
    return E;
 }
@@ -294,7 +299,7 @@ DecomposePerpendicularPartsRight(MatrixPolyType const& C, std::complex<double> K
                                  LinearWavefunction const& Psi1,
                                  LinearWavefunction const& Psi2,
                                  QuantumNumber const& QShift,
-                                 std::complex<double> Scale,
+                                 double TCond,
                                  bool HasEigenvalue1,
                                  double Tol,
                                  int Verbose)
@@ -341,8 +346,8 @@ DecomposePerpendicularPartsRight(MatrixPolyType const& C, std::complex<double> K
          }
 
          LinearSolveOrtho(F[m], Rho, Identity, OneMinusTransferRight_Ortho(Psi1, QShift, K*Diag, Psi2,
-                     Identity, Rho, Scale, HasEigenvalue1),
-                     Rhs, Tol, Verbose);
+                     Identity, Rho, HasEigenvalue1),
+                     TCond, Rhs, Tol, Verbose);
 
          //DEBUG_TRACE(m)(norm_frob(F[m]))(inner_prod(F[m], Rho));
 
@@ -373,7 +378,7 @@ DecomposePerpendicularPartsRight(KMatrixPolyType const& C,
                             LinearWavefunction const& Psi1,
                             LinearWavefunction const& Psi2,
                             QuantumNumber const& QShift,
-                            std::complex<double> Scale,
+                            double TCond,
                             bool HasEigenvalue1,
                             double Tol,
                             int Verbose)
@@ -385,7 +390,7 @@ DecomposePerpendicularPartsRight(KMatrixPolyType const& C,
    {
       std::complex<double> K = I->first;  // the momentum (complex phase)
       E[K] = DecomposePerpendicularPartsRight(I->second, I->first, Diag, Identity, Rho,
-                  Psi1, Psi2, QShift, Scale, HasEigenvalue1, Tol, Verbose);
+                  Psi1, Psi2, QShift, TCond, HasEigenvalue1, Tol, Verbose);
    }
    return E;
 }

--- a/mp-algorithms/triangular_mpo_solver_helpers.h
+++ b/mp-algorithms/triangular_mpo_solver_helpers.h
@@ -61,15 +61,16 @@ LinearSolve(MatrixOperator& x, Func F, MatrixOperator const& Rhs, double Tol = 1
 
 template <typename Func>
 void
-LinearSolveOrtho(MatrixOperator& x, MatrixOperator const& OrthoLeft, MatrixOperator const& OrthoRight, Func F, MatrixOperator const& Rhs, double Tol = 1E-14, int Verbose = 0)
+LinearSolveOrtho(MatrixOperator& x, MatrixOperator const& OrthoLeft, MatrixOperator const& OrthoRight, Func F, double Fcond, MatrixOperator const& Rhs, double Tol = 1E-14, int Verbose = 0)
 {
    int MaxIter = getenv_or_default("MP_GMRES_MAXITER", 10000);
    int m = 30;     // krylov subspace size
    int iter = 0;   // total number of iterations performed
 
-   double normb = norm_frob(Rhs);
+   double normb = 1.0; // norm_frob(Rhs);      // this could be norm_frob(Rhs) * condition number of F?
 
-   int Ret = GmResRefineOrtho(x, OrthoLeft, OrthoRight, F, Rhs, m, MaxIter, Tol, LinearAlgebra::Identity<MatrixOperator>(), Verbose);
+
+   int Ret = GmResRefineOrtho(x, OrthoLeft, OrthoRight, F, Fcond, Rhs, m, MaxIter, Tol, LinearAlgebra::Identity<MatrixOperator>(), Verbose);
 
    if (Ret != 0)
    {
@@ -132,7 +133,7 @@ DecomposePerpendicularPartsLeft(MatrixPolyType const& C, std::complex<double> K,
                                LinearWavefunction const& Psi1,
                                LinearWavefunction const& Psi2,
                                QuantumNumber const& QShift,
-                               std::complex<double> Scale,
+                               double TCond,
                                bool HasEigenvalue1,
                                double Tol,
                                int Verbose);
@@ -145,7 +146,7 @@ DecomposePerpendicularPartsLeft(KMatrixPolyType const& C,
                                 LinearWavefunction const& Psi1,
                                 LinearWavefunction const& Psi2,
                                 QuantumNumber const& QShift,
-                                std::complex<double> Scale,
+                                double TCond,
                                 bool HasEigenvalue1,
                                 double Tol,
                                 int Verbose);
@@ -160,7 +161,7 @@ DecomposePerpendicularPartsRight(MatrixPolyType const& C, std::complex<double> K
                                  LinearWavefunction const& Psi1,
                                  LinearWavefunction const& Psi2,
                                  QuantumNumber const& QShift,
-                                 std::complex<double> Scale,
+                                 double TCond,
                                  bool HasEigenvalue1,
                                  double Tol,
                                  int Verbose);
@@ -173,7 +174,7 @@ DecomposePerpendicularPartsRight(KMatrixPolyType const& C,
                                  LinearWavefunction const& Psi1,
                                  LinearWavefunction const& Psi2,
                                  QuantumNumber const& QShift,
-                                 std::complex<double> Scale,
+                                 double TCond,
                                  bool HasEigenvalue1,
                                  double Tol,
                                  int Verbose);

--- a/mp-algorithms/triangular_mpo_solver_simple.cpp
+++ b/mp-algorithms/triangular_mpo_solver_simple.cpp
@@ -41,6 +41,8 @@ SolveSimpleMPO_Left(std::vector<MatrixPolyType>& EMat,
    CHECK_EQUAL(Identity.Basis1(), Psi.Basis1());
    CHECK_EQUAL(Identity.Basis2(), Psi.Basis1());
 
+   double TCond = DefaultTCond;
+
    //DEBUG_TRACE(Verbose)(Degree)(Tol);
 
    int Dim = Op.Basis1().size();       // dimension of the MPO
@@ -124,7 +126,7 @@ SolveSimpleMPO_Left(std::vector<MatrixPolyType>& EMat,
             if (Verbose > 0)
                std::cerr << "Decomposing parts perpendicular to the unit matrix\n";
             E = DecomposePerpendicularPartsLeft(C, 1.0, Diag, Identity, Rho,
-                                                Psi, Psi, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                Psi, Psi, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
          {
@@ -158,6 +160,8 @@ SolveSimpleMPO_Right(std::vector<MatrixPolyType>& FMat,
    CHECK_EQUAL(Identity.Basis2(), Psi.Basis2());
    CHECK_EQUAL(Rho.Basis1(), Psi.Basis2());
    CHECK_EQUAL(Rho.Basis2(), Psi.Basis2());
+
+   double TCond = DefaultTCond;
 
    //DEBUG_TRACE(Verbose)(Degree)(Tol);
 
@@ -233,7 +237,7 @@ SolveSimpleMPO_Right(std::vector<MatrixPolyType>& FMat,
             if (Verbose > 0)
                std::cerr << "Decomposing parts perpendicular to the unit matrix\n";
             F = DecomposePerpendicularPartsRight(C, 1.0, Diag, Identity, Rho,
-                                                 Psi, Psi, QShift, 1.0, HasEigenvalue1, Tol, Verbose);
+                                                 Psi, Psi, QShift, TCond, HasEigenvalue1, Tol, Verbose);
          }
          else if (Verbose > 0)
          {

--- a/wavefunction/operator_actions.h
+++ b/wavefunction/operator_actions.h
@@ -610,19 +610,11 @@ struct OneMinusTransferLeft_Ortho
                               MatrixOperator const& RightUnit, bool Orthogonalize)
       : Psi1_(Psi1), QShift_(QShift), Op_(Op), Psi2_(Psi2),
         LeftUnit_(LeftUnit),
-        RightUnit_(RightUnit), Scale_(1.0), Orthogonalize_(Orthogonalize) { }
-
-   OneMinusTransferLeft_Ortho(LinearWavefunction const& Psi1, QuantumNumber const& QShift,
-                              BasicFiniteMPO const& Op, LinearWavefunction const& Psi2,
-                              MatrixOperator const& LeftUnit,
-                              MatrixOperator const& RightUnit, std::complex<double> Scale, bool Orthogonalize)
-      : Psi1_(Psi1), QShift_(QShift), Op_(Op), Psi2_(Psi2),
-        LeftUnit_(LeftUnit),
-        RightUnit_(RightUnit), Scale_(Scale), Orthogonalize_(Orthogonalize) { }
+        RightUnit_(RightUnit), Orthogonalize_(Orthogonalize) { }
 
    MatrixOperator operator()(MatrixOperator const& x) const
    {
-      MatrixOperator r = x-delta_shift(inject_left(x, Psi1_, Op_, Psi2_), QShift_)*Scale_;
+      MatrixOperator r = x-delta_shift(inject_left(x, Psi1_, Op_, Psi2_), QShift_);
       if (Orthogonalize_ && r.TransformsAs() == RightUnit_.TransformsAs())
          {
             //DEBUG_TRACE(inner_prod(r, RightUnit_))("this should be small");
@@ -639,7 +631,6 @@ struct OneMinusTransferLeft_Ortho
    LinearWavefunction const& Psi2_;
    MatrixOperator const& LeftUnit_;
    MatrixOperator const& RightUnit_;
-   std::complex<double> Scale_;
    bool Orthogonalize_;
 };
 
@@ -673,19 +664,11 @@ struct OneMinusTransferRight_Ortho
                               MatrixOperator const& Rho, bool Orthogonalize)
       : Psi1_(Psi1), QShift_(QShift), Op_(Op), Psi2_(Psi2),
         Identity_(Identity),
-        Rho_(Rho), Scale_(1.0), Orthogonalize_(Orthogonalize) { }
-
-   OneMinusTransferRight_Ortho(LinearWavefunction const& Psi1, QuantumNumber const& QShift,
-                              BasicFiniteMPO const& Op, LinearWavefunction const& Psi2,
-                              MatrixOperator const& Identity,
-                              MatrixOperator const& Rho, std::complex<double> Scale, bool Orthogonalize)
-      : Psi1_(Psi1), QShift_(QShift), Op_(Op), Psi2_(Psi2),
-        Identity_(Identity),
-        Rho_(Rho), Scale_(Scale), Orthogonalize_(Orthogonalize) { }
+        Rho_(Rho), Orthogonalize_(Orthogonalize) { }
 
    MatrixOperator operator()(MatrixOperator const& x) const
    {
-      MatrixOperator r = x-delta_shift(inject_right(x, Psi1_, Op_, Psi2_), adjoint(QShift_))*Scale_;
+      MatrixOperator r = x-delta_shift(inject_right(x, Psi1_, Op_, Psi2_), adjoint(QShift_));
       if (Orthogonalize_ && r.TransformsAs() == Rho_.TransformsAs())
          {
             r -= std::conj(inner_prod(r, Rho_)) * Identity_; // orthogonalize to the identity
@@ -699,7 +682,6 @@ struct OneMinusTransferRight_Ortho
    LinearWavefunction const& Psi2_;
    MatrixOperator const& Identity_;
    MatrixOperator const& Rho_;
-   std::complex<double> Scale_;
    bool Orthogonalize_;
 };
 


### PR DESCRIPTION
To get an accurate estimate of the forward error in GMRES, we need an estimate of the condition number.  This is now incorporated into mp-imoments-cross.

Also removed the Scale parameter, since this isn't used - mp-imoments-cross instead scales the MPS so that the desired eigenvalue is 1.0.