### PR TITLE
Preserve projected phase in iTDVP output

### DIFF
--- a/mp-algorithms/itdvp.cpp
+++ b/mp-algorithms/itdvp.cpp
@@ -132,6 +132,10 @@ iTDVP::Canonicalize()
       return;
 
    PsiCanonical = InfiniteWavefunctionLeft::Construct(Psi, QShift, scalar_prod(LambdaR, herm(LambdaR)), Normalize ? 0.0 : LogAmplitude);
+   std::complex<double> ScaleLog = ProjectedScaleLog;
+   if (Normalize)
+      ScaleLog = std::complex<double>(0.0, ScaleLog.imag());
+   PsiCanonical.scale_log(ScaleLog);
    Canonicalized = true;
 }
 
@@ -300,6 +304,11 @@ iTDVP::EvolveLeft(std::complex<double> Tau)
 
       this->OrthogonalizeLeftmostSite();
 
+      // The tangent-space projection removes the component parallel to the
+      // state, which carries the extensive phase/amplitude density -i E Tau.
+      if (Sweep == EvolutionSweeps)
+         ProjectedScaleLog += -I * E * Tau;
+
       if (Verbose > 0)
       {
          if (Sweep > 1)
@@ -385,6 +394,11 @@ iTDVP::EvolveRight(std::complex<double> Tau)
       this->SweepRight(Tau);
 
       this->OrthogonalizeRightmostSite();
+
+      // The tangent-space projection removes the component parallel to the
+      // state, which carries the extensive phase/amplitude density -i E Tau.
+      if (Sweep == EvolutionSweeps)
+         ProjectedScaleLog += -I * E * Tau;
 
       if (Verbose > 0)
       {

--- a/mp-algorithms/itdvp.cpp
+++ b/mp-algorithms/itdvp.cpp
@@ -949,6 +949,8 @@ iTDVP::UpdateHamiltonianLeft(std::complex<double> t, std::complex<double> dt)
    this->Canonicalize();
 
    std::tie(Psi, LambdaR) = get_left_canonical(PsiCanonical);
+   // The projected scale has now been embedded back into Psi via PsiCanonical.
+   ProjectedScaleLog = 0.0;
    C = Psi.end();
    --C;
 
@@ -1006,6 +1008,8 @@ iTDVP::UpdateHamiltonianRight(std::complex<double> t, std::complex<double> dt)
    this->Canonicalize();
 
    std::tie(LambdaR, Psi) = get_right_canonical(PsiCanonical);
+   // The projected scale has now been embedded back into Psi via PsiCanonical.
+   ProjectedScaleLog = 0.0;
    C = Psi.begin();
 
    if (Verbose > 1)

--- a/mp-algorithms/itdvp.cpp
+++ b/mp-algorithms/itdvp.cpp
@@ -949,6 +949,7 @@ iTDVP::UpdateHamiltonianLeft(std::complex<double> t, std::complex<double> dt)
    this->Canonicalize();
 
    std::tie(Psi, LambdaR) = get_left_canonical(PsiCanonical);
+   LogAmplitude = PsiCanonical.log_amplitude();
    // The projected scale has now been embedded back into Psi via PsiCanonical.
    ProjectedScaleLog = 0.0;
    C = Psi.end();
@@ -1008,6 +1009,7 @@ iTDVP::UpdateHamiltonianRight(std::complex<double> t, std::complex<double> dt)
    this->Canonicalize();
 
    std::tie(LambdaR, Psi) = get_right_canonical(PsiCanonical);
+   LogAmplitude = PsiCanonical.log_amplitude();
    // The projected scale has now been embedded back into Psi via PsiCanonical.
    ProjectedScaleLog = 0.0;
    C = Psi.begin();

--- a/mp-algorithms/itdvp.h
+++ b/mp-algorithms/itdvp.h
@@ -104,6 +104,11 @@ class iTDVP : public TDVP
       // Current energy per unit cell.
       std::complex<double> E;
 
+      // Cumulative logarithmic scale removed by the tangent-space projection.
+      // The real part contributes to the extensive amplitude, while the
+      // imaginary part is the phase per unit cell.
+      std::complex<double> ProjectedScaleLog = 0.0;
+
       InfiniteWavefunctionLeft PsiCanonical;
       // Flag to check whether the canonical form has been constructed for the current unit cell.
       bool Canonicalized;


### PR DESCRIPTION
Track the phase per unit cell in iTDVP.  This is a change from the current behavior, but also a 'bug fix' in the sense that it now agrees with itebd.