### PR TITLE
Fix site-dependent odd-bond selection in mp-itebd

### DIFF
--- a/mp/mp-itebd.cpp
+++ b/mp/mp-itebd.cpp
@@ -180,8 +180,8 @@ HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<dou
    for (auto x : decomp.b())
    {
       std::vector<SimpleOperator> Terms;
-      Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[BondH.size()-2]));
-      for (int i = 1; i < BondH.size()-2; i += 2)
+      Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[BondH.size()-1]));
+      for (int i = 1; i < BondH.size()-1; i += 2)
       {
          Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
       }

--- a/tests/suites/spinchain-tebd.yaml
+++ b/tests/suites/spinchain-tebd.yaml
@@ -275,6 +275,61 @@ fixtures:
           approx: 0.38481214455298
           abs: 1e-12
 
+
+  lat_plain:
+    run: spinchain -o lat
+    outputs:
+      lattice: lat
+
+  infinite_upup2:
+    from: lat_plain
+    run: mp-construct -l lat -o psi 0.5:0.5
+    outputs:
+      state: psi
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itebd_site0_sx:
+    from: infinite_upup2
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=2,Sx(0))" -o out -t 0.1 -n 1 -s 1
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.49750208263901
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itdvp_site0_sx:
+    from: infinite_upup2
+    run: mp-itdvp -w psi -H "lat:sum_unit(sites=2,Sx(0))" -o out -t 0.1 -n 1 -s 1 -m 4
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.49750208263901
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
 tests:
   tebd_identity_updates_norm_and_beta:
     use: finite_neel4_tebd_identity
@@ -329,6 +384,21 @@ tests:
     use:
       psi1: infinite_neel2_itebd_ising_real.state
       psi2: infinite_neel2_itdvp_ising_real.state
+    expect:
+      - ioverlap_real:
+          approx: 1.0
+          abs: 1e-12
+      - ioverlap_imag:
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          approx: 1.0
+          abs: 1e-12
+
+  itebd_site_dependent_two_site_drive_matches_itdvp:
+    use:
+      psi1: infinite_upup2_itebd_site0_sx.state
+      psi2: infinite_upup2_itdvp_site0_sx.state
     expect:
       - ioverlap_real:
           approx: 1.0


### PR DESCRIPTION
Closes #93.

This fixes a site-dependent odd-slice gate-ordering bug in `mp-itebd`.

Root cause:
- `AssembleHamiltonian()` was using `BondH[BondH.size()-2]` as the first odd-bond gate.
- The odd slice should start with the actual wraparound bond at the end of the list, i.e. `BondH[BondH.size()-1]`.
- For a 2-site unit cell this made the odd slice reuse bond 0 instead of applying the wraparound bond 1, so a drive intended only for site 0 was applied symmetrically.

What changed:
- fix the odd-slice wraparound bond selection in `mp/mp-itebd.cpp`
- add a regression in `tests/suites/spinchain-tebd.yaml` using a plain `spinchain` iMPS with
  `lat:sum_unit(sites=2,Sx(0))`

Validation:
- reproduced the reported behavior locally before the fix:
  - `mp-itdvp`: `Sz(0)` changes, `Sz(1)` stays at `0.5`
  - `mp-itebd`: both `Sz(0)` and `Sz(1)` changed identically
- after the fix, `mp-itebd` matches `mp-itdvp` exactly on that case
- `tests/suites/spinchain-tebd.yaml` passes in both optimized and debug mode.
