### PR TITLE
Fix multi-site gate handling in mp-itebd

### DIFF
--- a/mp/mp-itebd.cpp
+++ b/mp/mp-itebd.cpp
@@ -99,7 +99,7 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
    #pragma omp parallel for reduction(+:DeltaLogAmplitude)
    for (unsigned i = 0; i < Sz; i += 2)
    {
-      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[i/2], LogAmplitude, UOdd[i/2], SInfo);
+      TruncationInfo Info = DoTEBD(Psi[i], Psi[i+1], Lambda[i/2], DeltaLogAmplitude, UOdd[i/2], SInfo);
       if (Verbose > 0)
       {
          std::cout << "Bond=" << i

--- a/mp/mp-itebd.cpp
+++ b/mp/mp-itebd.cpp
@@ -128,6 +128,22 @@ struct HamiltonianGates
    std::vector<SimpleOperator> EvenContinuation;
 };
 
+SimpleOperator BondIdentity(OperatorComponent const& Left, OperatorComponent const& Right)
+{
+   return tensor_prod(SimpleOperator::make_identity(Left.LocalBasis1()),
+                      SimpleOperator::make_identity(Right.LocalBasis1()));
+}
+
+SimpleOperator ExponentiateBond(std::complex<double> Factor,
+                                SimpleOperator const& BondTerm,
+                                OperatorComponent const& Left,
+                                OperatorComponent const& Right)
+{
+   if (BondTerm.is_null())
+      return BondIdentity(Left, Right);
+   return Exponentiate(Factor * BondTerm);
+}
+
 // Construct the 2-body gates from the Hamiltonian.
 // We assume that the Hamiltonian has already been converted to an appropriate size unit cell.
 HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<double> Timestep, LTSDecomposition const& decomp)
@@ -168,7 +184,8 @@ HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<dou
       std::vector<SimpleOperator> Terms;
       for (int i = 0; i < BondH.size(); i += 2)
       {
-         Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
+         Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                          HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
       }
       EvenU.push_back(std::move(Terms));
    }
@@ -180,10 +197,12 @@ HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<dou
    for (auto x : decomp.b())
    {
       std::vector<SimpleOperator> Terms;
-      Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[BondH.size()-1]));
+      Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[BondH.size()-1],
+                                       HamMPO[BondH.size()-1], HamMPO[0]));
       for (int i = 1; i < BondH.size()-1; i += 2)
       {
-         Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
+         Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                          HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
       }
       OddU.push_back(std::move(Terms));
    }
@@ -196,7 +215,8 @@ HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<dou
       double x = decomp.a().front() + decomp.a().back();
       for (int i = 0; i < BondH.size(); i += 2)
       {
-         EvenContinuation.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
+         EvenContinuation.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                                     HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
       }
    }
 

--- a/tests/suites/spinchain-tebd.yaml
+++ b/tests/suites/spinchain-tebd.yaml
@@ -330,6 +330,157 @@ fixtures:
           approx: 0.5
           abs: 1e-12
 
+  infinite_upup2_itebd_site1_sx:
+    from: infinite_upup2
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=2,Sx(1))" -o out -t 0.1 -n 1 -s 1
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.49750208263901
+          abs: 1e-12
+
+  infinite_upup2_itdvp_site1_sx:
+    from: infinite_upup2
+    run: mp-itdvp -w psi -H "lat:sum_unit(sites=2,Sx(1))" -o out -t 0.1 -n 1 -s 1 -m 4
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.49750208263901
+          abs: 1e-12
+
+  infinite_upup3:
+    from: lat_plain
+    run: mp-construct -l lat -o psi 0.5:0.5:0.5
+    outputs:
+      state: psi
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup3_itebd_sites3_identity:
+    from: infinite_upup3
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=3,I(0))" -o out -t 0.1 -n 1 -s 1
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - attr_float:
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup4:
+    from: lat_plain
+    run: mp-construct -l lat -o psi 0.5:0.5:0.5:0.5
+    outputs:
+      state: psi
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(3)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup4_itebd_site3_sx:
+    from: infinite_upup4
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=4,Sx(3))" -o out -t 0.1 -n 1 -s 1
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(3)"
+          approx: 0.49750208263901
+          abs: 1e-12
+
+  infinite_upup4_itdvp_site3_sx:
+    from: infinite_upup4
+    run: mp-itdvp -w psi -H "lat:sum_unit(sites=4,Sx(3))" -o out -t 0.1 -n 1 -s 1 -m 4
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(3)"
+          approx: 0.49750208263901
+          abs: 1e-12
+
 tests:
   tebd_identity_updates_norm_and_beta:
     use: finite_neel4_tebd_identity
@@ -399,6 +550,57 @@ tests:
     use:
       psi1: infinite_upup2_itebd_site0_sx.state
       psi2: infinite_upup2_itdvp_site0_sx.state
+    expect:
+      - ioverlap_real:
+          approx: 1.0
+          abs: 1e-12
+      - ioverlap_imag:
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          approx: 1.0
+          abs: 1e-12
+
+
+  itebd_site_dependent_two_site_drive_on_second_site_matches_itdvp:
+    use:
+      psi1: infinite_upup2_itebd_site1_sx.state
+      psi2: infinite_upup2_itdvp_site1_sx.state
+    expect:
+      - ioverlap_real:
+          approx: 1.0
+          abs: 1e-12
+      - ioverlap_imag:
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          approx: 1.0
+          abs: 1e-12
+
+  itebd_identity_three_site_unit_cell_preserves_product_state:
+    use: infinite_upup3_itebd_sites3_identity
+    expect:
+      - attr_float:
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+
+  itebd_site_dependent_four_site_drive_matches_itdvp:
+    use:
+      psi1: infinite_upup4_itebd_site3_sx.state
+      psi2: infinite_upup4_itdvp_site3_sx.state
     expect:
       - ioverlap_real:
           approx: 1.0

--- a/tests/suites/spinchain-tebd.yaml
+++ b/tests/suites/spinchain-tebd.yaml
@@ -481,6 +481,49 @@ fixtures:
           approx: 0.49750208263901
           abs: 1e-12
 
+  infinite_upup4_itebd_sites4_identity_imag_parallel:
+    from: infinite_upup4
+    env:
+      OMP_NUM_THREADS: "4"
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=4,I(0))" -o out -t 0-0.1i -n 1 -s 1
+    outputs:
+      state:
+        glob: out*
+        select: newest
+    certify:
+      - attr_float:
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(3)"
+          approx: 0.5
+          abs: 1e-12
+      - ioverlap_real:
+          psi2: "{parent.state}"
+          approx: 0.90483741803596
+          abs: 1e-12
+      - ioverlap_imag:
+          psi2: "{parent.state}"
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          psi2: "{parent.state}"
+          approx: 0.90483741803596
+          abs: 1e-12
+
 tests:
   tebd_identity_updates_norm_and_beta:
     use: finite_neel4_tebd_identity
@@ -610,6 +653,30 @@ tests:
           abs: 1e-12
       - ioverlap_mag:
           approx: 1.0
+          abs: 1e-12
+
+  itebd_parallel_identity_four_site_unit_cell_tracks_amplitude:
+    use: infinite_upup4_itebd_sites4_identity_imag_parallel
+    expect:
+      - attr_float:
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(2)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(3)"
+          approx: 0.5
           abs: 1e-12
 
   infinite_product_state_expectations_and_self_overlap_match_exact_values:


### PR DESCRIPTION
## Summary
- treat structurally absent iTEBD bond terms as identity gates instead of exponentiating null operators
- fix odd-slice log-amplitude accumulation to use the reduction accumulator consistently
- add TEBD regressions for \, \, and a parallel \ amplitude case

## Details
This fixes the \ crash for multi-site unit-cell Hamiltonians such as \ and \, and keeps a regression for the odd-slice amplitude path under parallel execution.

The new site-dependent \ regression is checked against \.

Closes #95.