### PR TITLE
[codex] Add time-dependent Magnus support for TEBD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ set(MPTK_ALGORITHM_SOURCES
   mp-algorithms/stateslist.cpp
   mp-algorithms/tdvp.cpp
   mp-algorithms/tebd.cpp
+  mp-algorithms/time-dependent-mpo.cpp
   mp-algorithms/triangular_mpo_solver.cpp
   mp-algorithms/triangular_mpo_solver_cross.cpp
   mp-algorithms/triangular_mpo_solver_ea.cpp

--- a/Makefile.in
+++ b/Makefile.in
@@ -494,12 +494,12 @@ mp-misc = make-vb-state make-vb-su2
 
 mp-simple-marshall-qmc : random_wavefunc.o
 
-mp-tdvp : tdvp.o ef-optim.o number-parser.o tdvp-compositions.o expansion.o
+mp-tdvp : tdvp.o time-dependent-mpo.o ef-optim.o number-parser.o tdvp-compositions.o expansion.o
 
 # infinite tools
 
-mp-tebd : tebd.o number-parser.o
-mp-itebd : tebd.o number-parser.o
+mp-tebd : tebd.o time-dependent-mpo.o number-parser.o
+mp-itebd : tebd.o time-dependent-mpo.o number-parser.o
 
 mp-ibc-create : random_wavefunc.o triangular_mpo_solver.o momentum_operations.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o
 mp-ibc-correlation : number-parser.o
@@ -528,7 +528,7 @@ mp-aux-matrix : infinitewavefunctionleft.o
 mp-ies : infinitewavefunctionleft.o
 mp-ies-cross : infinitewavefunctionleft.o
 mp-aux-project : infinitewavefunctionleft.o packunpack.o
-mp-itebd : $(mpoobj) random_wavefunc.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o packunpack.o
+mp-itebd : $(mpoobj) time-dependent-mpo.o random_wavefunc.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o packunpack.o
 mp-dmrg : $(mpoobj) random_wavefunc.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o packunpack.o
 mp-dmrg-3s : $(mpoobj) random_wavefunc.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o packunpack.o
 mp-dmrg-2site : $(mpoobj) random_wavefunc.o infinitelattice.o stateslist.o ef-optim.o eigensolver.o packunpack.o
@@ -537,9 +537,9 @@ mp-scale : finitewavefunctionleft.o number-parser.o
 mp-iexpectation-cross : infinitewavefunctionleft.o
 mp-idivide :
 
-mp-itdvp : itdvp.o tdvp.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
-mp-ibc-tdvp : ibc-tdvp.o tdvp.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
-mp-ibc-dmrg : ibc-dmrg.o ibc-tdvp.o tdvp.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
+mp-itdvp : itdvp.o tdvp.o time-dependent-mpo.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
+mp-ibc-tdvp : ibc-tdvp.o tdvp.o time-dependent-mpo.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
+mp-ibc-dmrg : ibc-dmrg.o ibc-tdvp.o tdvp.o time-dependent-mpo.o ef-optim.o number-parser.o tdvp-compositions.o triangular_mpo_solver.o momentum_operations.o triangular_mpo_solver_helpers.o triangular_mpo_solver_simple.o expansion.o
 mp-matrix : write-matrix.o
 mp-aux-matrix : triangular_mpo_solver.o triangular_mpo_solver_helpers.o momentum_operations.o
 

--- a/linearalgebra/eigen.cc
+++ b/linearalgebra/eigen.cc
@@ -29,6 +29,18 @@
 namespace LinearAlgebra
 {
 
+#if defined(RANDOMIZE_VECTORS)
+namespace
+{
+
+double RandomSign()
+{
+   return randutil::rand() < 0.5 ? -1.0 : 1.0;
+}
+
+} // namespace
+#endif
+
 namespace Private
 {
 
@@ -559,7 +571,7 @@ struct ImplementSingularValueDecomposition<A, U, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (unsigned i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
          Vtres(i,LinearAlgebra::all) *= LinearAlgebra::conj(Phase);
       }
@@ -601,7 +613,7 @@ struct ImplementSingularValueDecomposition<A, U, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
          Vtres(i,LinearAlgebra::all) *= LinearAlgebra::conj(Phase);
       }
@@ -639,7 +651,7 @@ struct ImplementSingularValueDecompositionLeft<A, U, D,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
       }
 #endif
@@ -675,7 +687,7 @@ struct ImplementSingularValueDecompositionRight<A, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Vtres(i,LinearAlgebra::all) *= LinearAlgebra::conj(Phase);
       }
 #endif
@@ -719,7 +731,7 @@ struct ImplementSingularValueDecomposition<A, U, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
          Vtres(i,LinearAlgebra::all) *= LinearAlgebra::conj(Phase);
       }
@@ -781,7 +793,7 @@ struct ImplementSingularValueDecompositionFull<A, U, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < min_mn; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
          Vtres(i,LinearAlgebra::all) *= LinearAlgebra::conj(Phase);
       }
@@ -907,7 +919,7 @@ struct ImplementSingularValueDecompositionLeftFull<A, U, D,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < m; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Ures(LinearAlgebra::all,i) *= Phase;
       }
 #endif
@@ -976,7 +988,7 @@ struct ImplementSingularValueDecompositionRightFull<A, D, Vt,
 #if defined(RANDOMIZE_VECTORS)
       for (int i = 0; i < n; ++i)
       {
-         double Phase = (rand() % 2) * 2.0 - 1.0;
+         double Phase = RandomSign();
          Vtres(i,LinearAlgebra::all) *= Phase;
       }
 #endif

--- a/mp-algorithms/ibc-tdvp.cpp
+++ b/mp-algorithms/ibc-tdvp.cpp
@@ -25,8 +25,9 @@
 #include "linearalgebra/eigen.h"
 
 WindowHamiltonian::WindowHamiltonian(std::string HamStrBackground, std::string HamStrWindow,
-                                     int Size_, std::string Magnus_, std::string TimeVar_, int Verbose_)
-   : Hamiltonian(HamStrBackground, Size_, Magnus_, TimeVar_, Verbose_)
+                                     int Size_, int Verbose_, int MagnusOrder_, std::string TimeVar_,
+                                     int MagnusQuadrature_)
+   : Hamiltonian(HamStrBackground, Size_, Verbose_, MagnusOrder_, TimeVar_, MagnusQuadrature_)
 {
    if (HamStrWindow.empty())
    {

--- a/mp-algorithms/ibc-tdvp.cpp
+++ b/mp-algorithms/ibc-tdvp.cpp
@@ -18,11 +18,129 @@
 // ENDHEADER
 
 #include "ibc-tdvp.h"
+#include "time-dependent-mpo.h"
 #include "triangular_mpo_solver.h"
 #include "tensor/regularize.h"
 #include "tensor/tensor_eigen.h"
+#include "lattice/infinite-parser.h"
 #include "lattice/unitcell-parser.h"
 #include "linearalgebra/eigen.h"
+#include "parser/parser.h"
+#include <iterator>
+
+namespace
+{
+
+std::complex<double> const I(0.0, 1.0);
+
+int
+RoundDownMultiple(int n, int m)
+{
+   // Return the greatest multiple of positive m which is <= n.  For example,
+   // RoundDownMultiple(-1, 2) == -2.
+   CHECK(m > 0);
+   int r = n % m;
+   if (r < 0)
+      r += m;
+   return n - r;
+}
+
+int
+RoundUpMultiple(int n, int m)
+{
+   // Return the least multiple of positive m which is >= n.  For example,
+   // RoundUpMultiple(-3, 2) == -2, so negative inputs can round to negative
+   // multiples.
+   CHECK(m > 0);
+   int r = n % m;
+   if (r < 0)
+      r += m;
+   return r == 0 ? n : n + (m - r);
+}
+
+WavefunctionSectionLeft
+ExtendInitialWindow(WavefunctionSectionLeft const& Window,
+                    InfiniteWavefunctionLeft const& PsiLeft,
+                    InfiniteWavefunctionRight const& PsiRight,
+                    int SitesLeft, int SitesRight,
+                    int& Offset,
+                    int& WindowLeftSites, int& WindowRightSites,
+                    QuantumNumber& LeftQShift, QuantumNumber& RightQShift,
+                    int Verbose)
+{
+   LinearWavefunction PsiWindowLinear;
+   MatrixOperator Lambda;
+   int const InitialWindowSize = Window.size();
+
+   if (InitialWindowSize > 0)
+   {
+      std::tie(PsiWindowLinear, Lambda) = get_left_canonical(Window);
+      PsiWindowLinear.set_back(prod(PsiWindowLinear.get_back(), Lambda));
+   }
+   else
+   {
+      PsiWindowLinear = LinearWavefunction();
+      Lambda = Window.lambda_r();
+      Lambda = Window.LeftU() * Lambda * Window.RightU();
+   }
+
+   Offset -= SitesLeft;
+
+   auto CLeft = PsiLeft.end();
+   for (int i = 0; i < WindowLeftSites; ++i)
+      --CLeft;
+
+   for (int i = 0; i < SitesLeft; ++i)
+   {
+      if (CLeft == PsiLeft.begin())
+      {
+         LeftQShift = delta_shift(LeftQShift, PsiLeft.qshift());
+         CLeft = PsiLeft.end();
+      }
+      --CLeft;
+      PsiWindowLinear.push_front(delta_shift(*CLeft, LeftQShift));
+   }
+
+   if (CLeft == PsiLeft.begin())
+      LeftQShift = delta_shift(LeftQShift, PsiLeft.qshift());
+
+   if (SitesLeft > 0 && InitialWindowSize == 0)
+      PsiWindowLinear.set_back(prod(PsiWindowLinear.get_back(), Lambda));
+
+   auto CRight = PsiRight.begin();
+   for (int i = 0; i < WindowRightSites; ++i)
+      ++CRight;
+
+   for (int i = 0; i < SitesRight; ++i)
+   {
+      if (CRight == PsiRight.end())
+      {
+         RightQShift = delta_shift(RightQShift, adjoint(PsiRight.qshift()));
+         CRight = PsiRight.begin();
+      }
+      PsiWindowLinear.push_back(delta_shift(*CRight, RightQShift));
+      ++CRight;
+   }
+
+   if (CRight == PsiRight.end())
+      RightQShift = delta_shift(RightQShift, adjoint(PsiRight.qshift()));
+
+   if (SitesLeft == 0 && InitialWindowSize == 0)
+      PsiWindowLinear.set_front(prod(Lambda, PsiWindowLinear.get_front()));
+
+   WindowLeftSites = (WindowLeftSites + SitesLeft) % PsiLeft.size();
+   WindowRightSites = (WindowRightSites + SitesRight) % PsiRight.size();
+
+   if (PsiWindowLinear.empty())
+      return WavefunctionSectionLeft(Lambda);
+
+   MatrixOperator Identity = MatrixOperator::make_identity(PsiWindowLinear.Basis2());
+   return WavefunctionSectionLeft::ConstructFromLeftOrthogonal(std::move(PsiWindowLinear),
+                                                               Identity,
+                                                               std::max(Verbose-1, 0));
+}
+
+} // namespace
 
 WindowHamiltonian::WindowHamiltonian(std::string HamStrBackground, std::string HamStrWindow,
                                      int Size_, int Verbose_, int MagnusOrder_, std::string TimeVar_,
@@ -37,16 +155,92 @@ WindowHamiltonian::WindowHamiltonian(std::string HamStrBackground, std::string H
    else
    {
       WindowEmpty = false;
-      InfiniteLattice WindowLattice;
-      // NOTE: We cannot handle time-dependent windows at the moment. (TODO)
-      //std::tie(WindowOperator, WindowLattice) = ParseUniCellOperatorStringAndLattice(HamStrWindow);
-      std::tie(WindowMPO, WindowLattice) = ParseUnitCellOperatorAndLattice(HamStrWindow);
-      WindowTimeDependent = false;
+      std::tie(WindowOperator, WindowLattice) = ParseOperatorStringAndLattice(HamStrWindow);
+
+      try
+      {
+         WindowMPO = this->ParseWindowMPO();
+         WindowTimeDependent = false;
+      }
+      catch (Parser::ParserError&)
+      {
+         if (Verbose > 1)
+            std::cerr << "Parser error converting the window Hamiltonian to an MPO - assuming the window Hamiltonian is time-dependent.\n";
+         WindowMPO = this->ParseWindowMPO({{TimeVar, 0.0}});
+         WindowTimeDependent = true;
+      }
 
       // Cannot do this since operator== is not defined for InfiniteLattice
       // objects: we just assume that this is satified.
       //CHECK_EQUAL(Lattice, LatticeWindow);
    }
+}
+
+UnitCellMPO
+WindowHamiltonian::ParseWindowMPO(Function::ArgumentList Args) const
+{
+   for (auto const& Arg : WindowLattice.args())
+      if (Args.find(Arg.first) == Args.end())
+         Args.insert(Arg);
+
+   return ParseUnitCellOperator(WindowLattice.GetUnitCell(), 0, WindowOperator, Args, &WindowLattice);
+}
+
+UnitCellMPO
+WindowHamiltonian::WindowMPOForTime(std::complex<double> t, std::complex<double> dt) const
+{
+   if (!WindowTimeDependent)
+      return WindowMPO;
+
+   if (MagnusOrder > 4)
+      throw std::runtime_error("Magnus orders above four are not implemented yet.");
+
+   if (dt == 0.0)
+      return this->ParseWindowMPO({{TimeVar, t}});
+
+   int const QuadratureOrder = ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+   auto const Quadrature = GaussLegendreMagnusQuadrature(QuadratureOrder);
+
+   std::vector<UnitCellMPO> Samples;
+   Samples.reserve(QuadratureOrder);
+   for (double Node : Quadrature.Nodes)
+      Samples.push_back(this->ParseWindowMPO({{TimeVar, t + Node * dt}}));
+
+   UnitCellMPO Result = Quadrature.Weights[0] * Samples[0];
+   for (int i = 1; i < QuadratureOrder; ++i)
+      Result += Quadrature.Weights[i] * Samples[i];
+
+   if (MagnusOrder >= 4)
+   {
+      for (int i = 0; i < QuadratureOrder; ++i)
+      {
+         for (int j = i+1; j < QuadratureOrder; ++j)
+         {
+            double const Gamma = Quadrature.CommutatorWeights[i][j];
+            if (Gamma != 0.0)
+               Result += (-I * dt * Gamma) * commutator(Samples[i], Samples[j]);
+         }
+      }
+   }
+
+   return Result;
+}
+
+BasicTriangularMPO
+WindowHamiltonian::WindowTriangularMPO(int LeftUC, int RightUC,
+                                       std::complex<double> t, std::complex<double> dt) const
+{
+   UnitCellMPO WindowMPO_ = this->WindowMPOForTime(t, dt);
+   if (WindowMPO_.is_null())
+      return BasicTriangularMPO();
+
+   if ((LeftUC > WindowMPO_.offset())
+    || (RightUC < WindowMPO_.offset() + WindowMPO_.size()))
+      throw std::runtime_error("WindowHamiltonian: The requested range does not contain the support of the window operators in full unit cells.");
+
+   // We have to put the window MPO in triangular form so it can be added
+   // onto the triangular background MPO.
+   return make_triangular(ExtendToCover(WindowMPO_, RightUC-LeftUC, LeftUC));
 }
 
 BasicTriangularMPO
@@ -65,10 +259,11 @@ WindowHamiltonian::operator()(int Left, int Right, std::complex<double> t, std::
    int LeftRem = numerics::divp(-Left, UCSize).rem;
    int RightRem = numerics::divp(Right, UCSize).rem;
 
-   // This happens when left and right are both inside of a single unit cell.
-   // TODO: Can we handle this?
+   // The background is assembled by repeating whole unit cells, then attaching
+   // partial cells at the edges.  That requires at least one whole unit cell in
+   // the requested range.
    if (RightUC < LeftUC)
-      throw std::runtime_error("WindowHamiltonian: The desired range has no full unit cell. You must expand the window size manually to contain the operator in full unit cells.");
+      throw std::runtime_error("WindowHamiltonian: The requested range has no whole background unit cell.");
 
    // Extend the background Hamiltonian to fill the desired range with respect
    // to full unit cells (the leftover terms for partial unit cells are added
@@ -78,14 +273,9 @@ WindowHamiltonian::operator()(int Left, int Right, std::complex<double> t, std::
    // Add the window Hamiltonian if it exists.
    if (!WindowEmpty)
    {
-      // TODO: We should incorporate extra sites into the window beforehand if this is not satisfied.
-      if ((LeftUC * UCSize > WindowMPO.offset())
-       || (RightUC * UCSize < WindowMPO.offset() + WindowMPO.size()))
-         throw std::runtime_error("WindowHamiltonian: The range needs to contain the support of the window operators in full unit cells. You must expand the window size manually.");
-
-      // We have to put the window MPO in triangular form so it can be added
-      // onto the triangular background MPO.
-      Result = Result + make_triangular(ExtendToCover(WindowMPO, (RightUC-LeftUC) * UCSize, LeftUC * UCSize));
+      BasicTriangularMPO WindowMPO_ = this->WindowTriangularMPO(LeftUC * UCSize, RightUC * UCSize, t, dt);
+      if (!WindowMPO_.empty())
+         Result = Result + WindowMPO_;
    }
 
    // Now add the leftover terms to Hamiltonian by partially incorporating unit
@@ -116,9 +306,14 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
    HamWindow(Ham_), GMRESTol(Settings_.GMRESTol), FidTol(Settings_.FidTol), NExpand(Settings_.NExpand),
    Comoving(Settings_.Comoving), PsiLeft(Psi_.left()), PsiRight(Psi_.right())
 {
-   // We do not (currently) support time dependent Hamiltonians (TODO).
-   // (We would need to recalculate the left and right block Hamiltonians each timestep.)
+   // This IBC TDVP algorithm assumes stationary semi-infinite backgrounds.
+   // A time-dependent background would evolve those backgrounds too, which is
+   // a different algorithm rather than a local environment refresh.  Only the
+   // finite window Hamiltonian may be time-dependent here.
    CHECK(Ham.is_time_dependent() == false);
+
+   Time = InitialTime;
+   std::complex<double> dt = Comp.Beta.back()*Timestep;
 
    //-----------------------------------
    // Handle the boundary wavefunctions.
@@ -128,6 +323,29 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
    RightQShift = Psi_.right_qshift();
    WindowLeftSites = Psi_.window_left_sites();
    WindowRightSites = Psi_.window_right_sites();
+   Offset = Psi_.window_offset();
+
+   WavefunctionSectionLeft InitialWindow = Psi_.window();
+   if (!HamWindow.is_window_empty() && HamWindow.window_size() > 0)
+   {
+      int const RequiredLeft = RoundDownMultiple(HamWindow.window_offset(), std::ssize(PsiLeft));
+      int const RequiredRight = RoundUpMultiple(HamWindow.window_offset() + HamWindow.window_size(),
+                                                std::ssize(PsiRight));
+      int const SitesLeft = std::max(Offset - RequiredLeft, 0);
+      int const SitesRight = std::max(RequiredRight - (Offset + std::ssize(InitialWindow)), 0L);
+
+      if (SitesLeft > 0 || SitesRight > 0)
+      {
+         if (Verbose > 0)
+            std::cout << "Expanding initial window by " << SitesLeft << " sites on the left and "
+                      << SitesRight << " sites on the right to cover the window Hamiltonian." << '\n';
+
+         InitialWindow = ExtendInitialWindow(InitialWindow, PsiLeft, PsiRight,
+                                             SitesLeft, SitesRight,
+                                             Offset, WindowLeftSites, WindowRightSites,
+                                             LeftQShift, RightQShift, Verbose);
+      }
+   }
 
    if (Verbose > 0)
       std::cout << "Constructing Hamiltonian block operators..." << '\n';
@@ -239,21 +457,23 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
    // Handle the window.
    //-------------------
 
-   Offset = Psi_.window_offset();
    LeftStop = Settings_.EvolutionWindowLeft;
    RightStop = Settings_.EvolutionWindowRight;
+   if (LeftStop == RightStop + 1)
+      ++RightStop;
    Site = Offset;
 
    // Check whether there are any sites in the window, and if not, add some.
-   if (Psi_.window_size() == 0)
+   if (InitialWindow.size() == 0)
    {
-      // TODO: Expand window automatically.
-      if (!HamWindow.is_window_empty())
-         throw std::runtime_error("fatal: If using a window operator, your initial wavefunction window cannot be empty. You must expand the window size manually to contain the operator in full unit cells.");
+      // A finite window operator with nonzero support is incorporated into
+      // InitialWindow above.  An empty window can only remain here when there
+      // is no finite window support to include.
+      CHECK(HamWindow.is_window_empty() || HamWindow.window_size() == 0);
 
       Psi = LinearWavefunction();
-      MatrixOperator Lambda = Psi_.window().lambda_r();
-      Lambda = Psi_.window().LeftU() * Lambda * Psi_.window().RightU();
+      MatrixOperator Lambda = InitialWindow.lambda_r();
+      Lambda = InitialWindow.LeftU() * Lambda * InitialWindow.RightU();
 
       HamiltonianWindow = BasicTriangularMPO();
 
@@ -261,8 +481,6 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
          std::cout << "Initial window size = 0, adding site to window..." << '\n';
 
       this->ExpandWindowRight();
-      if (LeftStop == RightStop + 1)
-         ++RightStop;
 
       // Incorporate the Lambda matrix into the wavefunction.
       *C = prod(Lambda, *C);
@@ -272,13 +490,13 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
    else // Handle windows with > 0 sites.
    {
       MatrixOperator Lambda;
-      std::tie(Psi, Lambda) = get_left_canonical(Psi_.window());
+      std::tie(Psi, Lambda) = get_left_canonical(InitialWindow);
 
       C = Psi.begin();
 
       // Get the Hamiltonian for the window, being the sum of the background
       // Hamiltonian and the window Hamiltonian.
-      HamiltonianWindow = HamWindow(Psi_.window_offset(), Psi_.window_offset() + Psi_.window_size());
+      HamiltonianWindow = HamWindow(Offset, Offset + std::ssize(Psi), Time-dt, dt);
 
       // Update iterators for the boundary MPOs to be added into the window when expanding.
       for (int i = 0; i < WindowLeftSites; ++i)
@@ -308,12 +526,24 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
    if (Comoving != 0)
       LeftStop = RightStop - Comoving + 1;
 
+   if (!HamWindow.is_window_empty() && HamWindow.window_size() > 0)
+   {
+      LeftStop = std::min(LeftStop, HamWindow.window_offset());
+      RightStop = std::max(RightStop, HamWindow.window_offset() + HamWindow.window_size() - 1);
+   }
+
    // Ensure that the window contains LeftStop and RightStop.
    while (LeftStop < Offset)
       this->ExpandWindowLeft();
 
-   while (RightStop > Offset + Psi.size()-1)
+   while (RightStop > Offset + std::ssize(Psi) - 1)
       this->ExpandWindowRight();
+
+   // Keep a guard site outside each edge of the evolution window before the
+   // initial orthogonalization passes.  Waiting until after the pass can put
+   // the orthogonality centre exactly on a finite-window boundary.
+   if (LeftStop == Offset)
+      this->ExpandWindowLeft();
 
    //----------------------------------------------------
    // Initialize the evolution window expansion criteria.
@@ -341,15 +571,14 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
       HamL.pop_back();
    }
 
-   // Add an extra site to the left of the evolution window if there isn't one.
-   if (LeftStop == Offset)
-      this->ExpandWindowLeft();
-
    // Save the left reference A-matrices.
    CRefLeft = *C;
    --C;
    CRefLeft2 = *C;
    ++C;
+
+   if (RightStop == Offset + std::ssize(Psi) - 1)
+      this->ExpandWindowRight();
 
    // Left-orthogonalize the window.
    while (Site < RightStop)
@@ -372,10 +601,6 @@ IBC_TDVP::IBC_TDVP(IBCWavefunction const& Psi_, WindowHamiltonian const& Ham_, I
 
       HamR.pop_front();
    }
-
-   // Add an extra site to the right of the evolution window if there isn't one.
-   if (RightStop == Offset + Psi.size()-1)
-      this->ExpandWindowRight();
 
    // Save the right reference A-matrices.
    CRefRight = *C;
@@ -456,7 +681,7 @@ IBC_TDVP::ExpandWindowRight()
    // Reset iterators to previous location.
    C = Psi.end();
    H = HamiltonianWindow.end();
-   for (int i = Offset + Psi.size()-1; i >= Site; --i)
+   for (auto i = Offset + std::ssize(Psi) - 1; i >= Site; --i)
       --C, --H;
 
    ++HRight, ++CRight, ++HamRight;
@@ -510,7 +735,7 @@ IBC_TDVP::ExpandEvolutionWindowRight()
    PRECONDITION(Site == RightStop);
 
    // Expand the window if needed.
-   while (RightStop >= Offset + Psi.size()-1 - 1)
+   while (RightStop >= Offset + std::ssize(Psi) - 2)
       this->ExpandWindowRight();
 
    ++RightStop;
@@ -640,7 +865,7 @@ IBC_TDVP::SweepRightEW(std::complex<double> Tau, bool Expand)
    {
       // Add an extra site to the window if there isn't one.
       // (This shouldn't be able to happen anyway(?), so this is here just in case.)
-      if (RightStop == Offset + Psi.size()-1)
+      if (RightStop == Offset + std::ssize(Psi) - 1)
          this->ExpandWindowRight();
       this->ExpandRight();
    }
@@ -668,7 +893,7 @@ IBC_TDVP::SweepRightEW(std::complex<double> Tau, bool Expand)
 
       if (Expand)
       {
-         if (RightStop == Offset + Psi.size()-1)
+         if (RightStop == Offset + std::ssize(Psi) - 1)
             this->ExpandWindowRight();
          this->ExpandRight();
       }
@@ -686,7 +911,7 @@ IBC_TDVP::SweepRightFinalEW(std::complex<double> Tau, bool Expand)
 {
    // Add an extra site to the window if there isn't one.
    // (This shouldn't be able to happen anyway(?), so this is here just in case.)
-   if (RightStop == Offset + Psi.size()-1)
+   if (RightStop == Offset + std::ssize(Psi) - 1)
       this->ExpandWindowRight();
 
    if (Expand)
@@ -725,7 +950,7 @@ IBC_TDVP::SweepRightFinalEW(std::complex<double> Tau, bool Expand)
 
       if (Expand)
       {
-         if (RightStop == Offset + Psi.size()-1)
+         if (RightStop == Offset + std::ssize(Psi) - 1)
             this->ExpandWindowRight();
          this->ExpandRight();
       }
@@ -740,8 +965,59 @@ IBC_TDVP::SweepRightFinalEW(std::complex<double> Tau, bool Expand)
 }
 
 void
+IBC_TDVP::UpdateWindowHamiltonian(std::complex<double> t, std::complex<double> dt)
+{
+   if (!HamWindow.is_window_time_dependent())
+      return;
+
+   HamiltonianWindow = HamWindow(Offset, Offset + std::ssize(Psi), t, dt);
+
+   if (Verbose > 1)
+      std::cout << "Recalculating window Hamiltonian environment..." << '\n';
+
+   StateComponent LeftBoundary = HamL.front();
+   StateComponent RightBoundary = HamR.back();
+
+   HamL = std::deque<StateComponent>();
+   HamL.push_back(LeftBoundary);
+
+   LinearWavefunction::iterator CLocal = Psi.begin();
+   BasicTriangularMPO::const_iterator HLocal = HamiltonianWindow.begin();
+   int SiteLocal = Offset;
+
+   while (SiteLocal < Site)
+   {
+      if (Verbose > 1)
+         std::cout << "Site " << SiteLocal << '\n';
+      HamL.push_back(contract_from_left(*HLocal, herm(*CLocal), HamL.back(), *CLocal));
+      ++HLocal, ++CLocal, ++SiteLocal;
+   }
+
+   HamR = std::deque<StateComponent>();
+   HamR.push_front(RightBoundary);
+
+   CLocal = Psi.end();
+   HLocal = HamiltonianWindow.end();
+   SiteLocal = Offset + std::ssize(Psi);
+
+   while (SiteLocal > Site + 1)
+   {
+      --HLocal, --CLocal, --SiteLocal;
+      if (Verbose > 1)
+         std::cout << "Site " << SiteLocal << '\n';
+      HamR.push_front(contract_from_right(herm(*HLocal), *CLocal, HamR.front(), herm(*CLocal)));
+   }
+
+   C = Psi.begin();
+   H = HamiltonianWindow.begin();
+   for (int i = Offset; i < Site; ++i)
+      ++C, ++H;
+}
+
+void
 IBC_TDVP::Evolve(bool Expand)
 {
+   Time = InitialTime + ((double) TStep)*Timestep;
    ++TStep;
    Eps1SqSum = 0.0;
    Eps2SqSum = 0.0;
@@ -753,10 +1029,12 @@ IBC_TDVP::Evolve(bool Expand)
       if (TStep % NExpand == 0)
          this->ExpandEvolutionWindowRight();
 
+   this->UpdateWindowHamiltonian(Time, (*Alpha)*Timestep);
    if (Comoving == 0)
       this->SweepLeftEW((*Alpha)*Timestep, Expand);
    else
       this->SweepLeft((*Alpha)*Timestep, Expand);
+   Time += (*Alpha)*Timestep;
    ++Alpha;
 
    if (NExpand != 0 && Comoving == 0)
@@ -765,25 +1043,32 @@ IBC_TDVP::Evolve(bool Expand)
 
    while (Alpha != Comp.Alpha.cend())
    {
+      this->UpdateWindowHamiltonian(Time, (*Beta)*Timestep);
       this->SweepRightEW((*Beta)*Timestep, Expand);
+      Time += (*Beta)*Timestep;
       ++Beta;
 
+      this->UpdateWindowHamiltonian(Time, (*Alpha)*Timestep);
       if (Comoving == 0)
          this->SweepLeftEW((*Alpha)*Timestep, Expand);
       else
          this->SweepLeft((*Alpha)*Timestep, Expand);
+      Time += (*Alpha)*Timestep;
       ++Alpha;
    }
 
+   this->UpdateWindowHamiltonian(Time, (*Beta)*Timestep);
    if (Epsilon)
       this->SweepRightFinalEW((*Beta)*Timestep, Expand);
    else
       this->SweepRightEW((*Beta)*Timestep, Expand);
+   Time += (*Beta)*Timestep;
 }
 
 void
 IBC_TDVP::Evolve2()
 {
+   Time = InitialTime + ((double) TStep)*Timestep;
    ++TStep;
    TruncErrSum = 0.0;
 
@@ -795,7 +1080,7 @@ IBC_TDVP::Evolve2()
       if (TStep % NExpand == 0)
       {
          // Expand the window if needed.
-         while (RightStop >= Offset + Psi.size()-1 - 1)
+         while (RightStop >= Offset + std::ssize(Psi) - 2)
             this->ExpandWindowRight();
 
          ++RightStop;
@@ -807,7 +1092,9 @@ IBC_TDVP::Evolve2()
    }
 
 
+   this->UpdateWindowHamiltonian(Time, (*Alpha)*Timestep);
    this->SweepLeft2((*Alpha)*Timestep);
+   Time += (*Alpha)*Timestep;
    ++Alpha;
 
    if (NExpand != 0 && Comoving == 0)
@@ -822,15 +1109,21 @@ IBC_TDVP::Evolve2()
       }
    }
 
+   this->UpdateWindowHamiltonian(Time, (*Beta)*Timestep);
    this->SweepRight2((*Beta)*Timestep);
+   Time += (*Beta)*Timestep;
    ++Beta;
 
    while (Alpha != Comp.Alpha.cend())
    {
+      this->UpdateWindowHamiltonian(Time, (*Alpha)*Timestep);
       this->SweepLeft2((*Alpha)*Timestep);
+      Time += (*Alpha)*Timestep;
       ++Alpha;
 
+      this->UpdateWindowHamiltonian(Time, (*Beta)*Timestep);
       this->SweepRight2((*Beta)*Timestep);
+      Time += (*Beta)*Timestep;
       ++Beta;
    }
 

--- a/mp-algorithms/ibc-tdvp.cpp
+++ b/mp-algorithms/ibc-tdvp.cpp
@@ -192,8 +192,7 @@ WindowHamiltonian::WindowMPOForTime(std::complex<double> t, std::complex<double>
    if (!WindowTimeDependent)
       return WindowMPO;
 
-   if (MagnusOrder > 4)
-      throw std::runtime_error("Magnus orders above four are not implemented yet.");
+   ValidateMagnusOrder(MagnusOrder);
 
    if (dt == 0.0)
       return this->ParseWindowMPO({{TimeVar, t}});

--- a/mp-algorithms/ibc-tdvp.h
+++ b/mp-algorithms/ibc-tdvp.h
@@ -31,7 +31,8 @@ class WindowHamiltonian : public Hamiltonian
 
       // If Size == 0, do not rescale Hamiltonian size.
       WindowHamiltonian(std::string HamStrBackground, std::string HamStrWindow,
-                        int Size = 0, std::string Magnus = "2", std::string TimeVar = "t", int Verbose = 0);
+                        int Size = 0, int Verbose = 0, int MagnusOrder = 2,
+                        std::string TimeVar = "t", int MagnusQuadrature = 0);
 
       // Get the Hamiltonian MPO to evolve from t to t + dt.
       BasicTriangularMPO operator()(int Left, int Right, std::complex<double> t = 0.0, std::complex<double> dt = 0.0) const;

--- a/mp-algorithms/ibc-tdvp.h
+++ b/mp-algorithms/ibc-tdvp.h
@@ -40,11 +40,17 @@ class WindowHamiltonian : public Hamiltonian
       bool is_window_empty() const { return WindowEmpty; }
       bool is_window_time_dependent() const { return WindowTimeDependent; }
 
-      bool window_size() const { return WindowMPO.size(); }
-      bool window_offset() const { return WindowMPO.offset(); }
+      int window_size() const { return WindowMPO.size(); }
+      int window_offset() const { return WindowMPO.offset(); }
 
    protected:
+      UnitCellMPO ParseWindowMPO(Function::ArgumentList Args = Function::ArgumentList()) const;
+      UnitCellMPO WindowMPOForTime(std::complex<double> t, std::complex<double> dt) const;
+      BasicTriangularMPO WindowTriangularMPO(int LeftUC, int RightUC,
+                                             std::complex<double> t, std::complex<double> dt) const;
+
       std::string WindowOperator;
+      InfiniteLattice WindowLattice;
       UnitCellMPO WindowMPO;
       bool WindowEmpty;
       bool WindowTimeDependent;
@@ -96,6 +102,10 @@ class IBC_TDVP : public TDVP
 
       // Evolve the window by one time step using 2TDVP.
       void Evolve2();
+
+      // Update a time-dependent window Hamiltonian and rebuild the effective
+      // environments around the current orthogonality centre.
+      void UpdateWindowHamiltonian(std::complex<double> t, std::complex<double> dt);
 
       double GMRESTol;
       double FidTol;

--- a/mp-algorithms/tdvp.cpp
+++ b/mp-algorithms/tdvp.cpp
@@ -20,6 +20,7 @@
 
 #include "tdvp.h"
 #include "lanczos-exponential-new.h"
+#include "time-dependent-mpo.h"
 #include "tensor/regularize.h"
 #include "tensor/tensor_eigen.h"
 #include "linearalgebra/eigen.h"
@@ -66,9 +67,13 @@ struct HEff2
 };
 
 Hamiltonian::Hamiltonian(std::string HamStr, int Size_,
-                         std::string Magnus_, std::string TimeVar_, int Verbose_)
-   : Size(Size_), Magnus(Magnus_), TimeVar(TimeVar_), Verbose(Verbose_)
+                         int Verbose_, int MagnusOrder_, std::string TimeVar_,
+                         int MagnusQuadrature_)
+   : Size(Size_), MagnusOrder(MagnusOrder_), MagnusQuadrature(MagnusQuadrature_),
+     TimeVar(TimeVar_), Verbose(Verbose_)
 {
+   ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+
    std::tie(HamOperator, Lattice) = ParseOperatorStringAndLattice(HamStr);
 
    // Attempt to convert the operator into an MPO. If it works, then the
@@ -101,23 +106,9 @@ Hamiltonian::operator()(std::complex<double> t, std::complex<double> dt) const
       return HamMPO;
    else
    {
-      BasicTriangularMPO HamMPO_;
-
-      if (dt == 0.0)
-         HamMPO_ = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t}});
-      else if (Magnus == "2")
-      {
-         std::complex<double> Time = t + 0.5*dt;
-         HamMPO_ = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, Time}});
-      }
-      else if (Magnus == "4")
-      {
-         std::complex<double> t1 = t + (0.5 - std::sqrt(3.0)/6.0) * dt;
-         std::complex<double> t2 = t + (0.5 + std::sqrt(3.0)/6.0) * dt;
-         BasicTriangularMPO A1 = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t1}});
-         BasicTriangularMPO A2 = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t2}});
-         HamMPO_ = 0.5 * (A1 + A2) - I * dt * (std::sqrt(3.0) / 12.0) * commutator(A1, A2);
-      }
+      BasicTriangularMPO HamMPO_ = TimeDependentHamiltonianMPO(Lattice, HamOperator, TimeVar,
+                                                               t, dt, MagnusOrder,
+                                                               MagnusQuadrature);
 
       if (Size != 0)
          HamMPO_ = repeat(HamMPO_, Size / HamMPO_.size());

--- a/mp-algorithms/tdvp.h
+++ b/mp-algorithms/tdvp.h
@@ -35,7 +35,8 @@ class Hamiltonian
 
       // If Size == 0, do not rescale Hamiltonian size.
       Hamiltonian(std::string HamStr, int Size = 0,
-                  std::string Magnus = "2", std::string TimeVar = "t", int Verbose = 0);
+                  int Verbose = 0, int MagnusOrder = 2,
+                  std::string TimeVar = "t", int MagnusQuadrature = 0);
 
       // Get the Hamiltonian MPO to evolve from t to t + dt.
       BasicTriangularMPO operator()(std::complex<double> t = 0.0, std::complex<double> dt = 0.0) const;
@@ -48,7 +49,8 @@ class Hamiltonian
       InfiniteLattice Lattice;
       std::string HamOperator;
       int Size;
-      std::string Magnus;
+      int MagnusOrder;
+      int MagnusQuadrature;
       std::string TimeVar;
       bool TimeDependent;
       BasicTriangularMPO HamMPO;

--- a/mp-algorithms/tebd.cpp
+++ b/mp-algorithms/tebd.cpp
@@ -295,6 +295,12 @@ AssembleFiniteTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
       return PrepareFiniteTEBDHamiltonian(HamMPO, PsiSize);
    };
 
+   // Each split Hamiltonian family has its own time coverage over the full
+   // timestep.  The Suzuki-Trotter product applies even and odd gates in an
+   // interleaved order, but the even coefficients and odd coefficients each
+   // sum to one and each cover [StepStart, StepStart+Timestep].  Keep separate
+   // clocks for the two families; a single chronological application clock
+   // would sample the odd Hamiltonian at the wrong interval for leapfrog/Strang.
    std::vector<std::vector<SimpleOperator>> EvenU;
    std::complex<double> EvenTime = StepStart;
    for (double x : decomp.a())
@@ -316,6 +322,9 @@ AssembleFiniteTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
    std::vector<SimpleOperator> EvenContinuation;
    if (decomp.a().size() == decomp.b().size()+1)
    {
+      // The evolution loop defers the final even slice and merges it with the
+      // next timestep's first even slice.  This is one even-family interval
+      // from the previous slice start through the next first-slice endpoint.
       std::complex<double> SliceStart = StepStart - decomp.a().back() * Timestep;
       std::complex<double> SliceTimestep = (decomp.a().back() + decomp.a().front()) * Timestep;
       EvenContinuation = AssembleFiniteTEBDEvenSlice(HamiltonianSlice(SliceStart, SliceTimestep), SliceTimestep);
@@ -469,6 +478,9 @@ AssemblePeriodicTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
       return PreparePeriodicTEBDHamiltonianUnitCell(HamMPO, Coarsegrain, PsiSize);
    };
 
+   // See the finite time-dependent builder for the split-family clock
+   // convention.  Periodic TEBD uses the same independent even and odd clocks;
+   // the interleaved gate application order is not a single physical clock.
    std::vector<std::vector<SimpleOperator>> EvenU;
    std::complex<double> EvenTime = StepStart;
    for (double x : decomp.a())
@@ -490,6 +502,8 @@ AssemblePeriodicTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
    std::vector<SimpleOperator> EvenContinuation;
    if (decomp.a().size() == decomp.b().size()+1)
    {
+      // Merge the previous final even-family interval with this timestep's
+      // first even-family interval.
       std::complex<double> SliceStart = StepStart - decomp.a().back() * Timestep;
       std::complex<double> SliceTimestep = (decomp.a().back() + decomp.a().front()) * Timestep;
       EvenContinuation = AssemblePeriodicTEBDEvenSlice(HamiltonianSlice(SliceStart, SliceTimestep), SliceTimestep);

--- a/mp-algorithms/tebd.cpp
+++ b/mp-algorithms/tebd.cpp
@@ -19,7 +19,10 @@
 // ENDHEADER
 
 #include "mp-algorithms/tebd.h"
+#include "mp-algorithms/time-dependent-mpo.h"
+#include "common/statistics.h"
 #include "mps/density.h"
+#include <stdexcept>
 
 // returns the number of digits of precision used in the decimal number f
 int Digits(std::string const& f)
@@ -138,6 +141,355 @@ Decompositions = {
                                                {0.18793069262651671457, 0.5553,
                                                      0.12837035888423653774, -0.84315275357471264676})}};
 
+// FIXME: The finite and periodic gate assembly below intentionally duplicates
+// some traversal logic while finite/infinite MPO and lattice boundary semantics
+// are still represented separately.  Consolidate this once those abstractions
+// make edge versus wraparound behavior explicit.
+
+SimpleOperator
+TEBDBondIdentity(OperatorComponent const& Left, OperatorComponent const& Right)
+{
+   return tensor_prod(SimpleOperator::make_identity(Left.LocalBasis1()),
+                      SimpleOperator::make_identity(Right.LocalBasis1()));
+}
+
+SimpleOperator
+ExponentiateTEBDBond(std::complex<double> Factor,
+                     SimpleOperator const& BondTerm,
+                     OperatorComponent const& Left,
+                     OperatorComponent const& Right)
+{
+   if (BondTerm.is_null())
+      return TEBDBondIdentity(Left, Right);
+   return Exponentiate(Factor * BondTerm);
+}
+
+BasicTriangularMPO
+PrepareFiniteTEBDHamiltonian(BasicTriangularMPO HamMPO, int PsiSize)
+{
+   if (HamMPO.size() < PsiSize)
+      HamMPO = repeat(HamMPO, PsiSize / HamMPO.size());
+   return HamMPO;
+}
+
+std::vector<SimpleOperator>
+FiniteTEBDBondHamiltonian(BasicTriangularMPO const& HamMPO)
+{
+   if (HamMPO.size() < 2)
+      return {};
+
+   std::vector<SimpleOperator> BondH(HamMPO.size()-1);
+   auto SplitTerms = SplitMPO(HamMPO);
+   for (int i = 0; i < SplitTerms.size(); ++i)
+   {
+      for (auto const& op : SplitTerms[i])
+      {
+         if (op.size() == 1)
+         {
+            // Split single-site operators over the two bonds, unless they are at the edge.
+            if (i == 0)
+            {
+               SimpleRedOperator p = tensor_prod(op[0](0,0), HamMPO[i+1](0,0));
+               BondH[i] += p.scalar();
+            }
+            else if (i == HamMPO.size()-1)
+            {
+               SimpleRedOperator p = tensor_prod(HamMPO[i-1](0,0), op[0](0,0));
+               BondH[i-1] += p.scalar();
+            }
+            else
+            {
+               SimpleRedOperator p = tensor_prod(op[0](0,0), HamMPO[i+1](0,0));
+               BondH[i] += 0.5 * p.scalar();
+               SimpleRedOperator q = tensor_prod(HamMPO[i-1](0,0), op[0](0,0));
+               BondH[i-1] += 0.5 * q.scalar();
+            }
+         }
+         else if (op.size() == 2)
+         {
+            // Ignore terms that cross beyond the finite-system boundary.
+            if (i < HamMPO.size()-1)
+               BondH[i] += coarse_grain(op).scalar();
+         }
+         else
+         {
+            throw std::runtime_error("fatal: operator has support over more than 2 sites.");
+         }
+      }
+   }
+
+   return BondH;
+}
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
+                            std::complex<double> SliceTimestep)
+{
+   std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
+   std::vector<SimpleOperator> Terms;
+   for (int i = 0; i < BondH.size(); i += 2)
+   {
+      Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
+                                           HamMPO[i], HamMPO[i+1]));
+   }
+   return Terms;
+}
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDOddSlice(BasicTriangularMPO const& HamMPO,
+                           std::complex<double> SliceTimestep)
+{
+   std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
+   std::vector<SimpleOperator> Terms;
+   for (int i = 1; i < BondH.size(); i += 2)
+   {
+      Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
+                                           HamMPO[i], HamMPO[i+1]));
+   }
+   return Terms;
+}
+
+TEBDHamiltonianGates
+AssembleFiniteTEBDHamiltonian(BasicTriangularMPO const& HamMPO,
+                              std::complex<double> Timestep,
+                              LTSDecomposition const& decomp)
+{
+   std::vector<std::vector<SimpleOperator>> EvenU;
+   for (auto x : decomp.a())
+      EvenU.push_back(AssembleFiniteTEBDEvenSlice(HamMPO, x*Timestep));
+
+   std::vector<std::vector<SimpleOperator>> OddU;
+   for (auto x : decomp.b())
+      OddU.push_back(AssembleFiniteTEBDOddSlice(HamMPO, x*Timestep));
+
+   std::vector<SimpleOperator> EvenContinuation;
+   if (decomp.a().size() == decomp.b().size()+1)
+      EvenContinuation = AssembleFiniteTEBDEvenSlice(HamMPO, (decomp.a().front() + decomp.a().back()) * Timestep);
+
+   return {EvenU, OddU, EvenContinuation};
+}
+
+TEBDHamiltonianGates
+AssembleFiniteTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
+                                           std::string const& HamOperator,
+                                           std::string const& TimeVar,
+                                           std::complex<double> StepStart,
+                                           std::complex<double> Timestep,
+                                           LTSDecomposition const& decomp,
+                                           int MagnusOrder,
+                                           int MagnusQuadrature,
+                                           int PsiSize)
+{
+   auto HamiltonianSlice = [&](std::complex<double> SliceStart, std::complex<double> SliceTimestep)
+   {
+      BasicTriangularMPO HamMPO = TimeDependentHamiltonianMPO(Lattice, HamOperator, TimeVar,
+                                                              SliceStart, SliceTimestep,
+                                                              MagnusOrder, MagnusQuadrature);
+      return PrepareFiniteTEBDHamiltonian(HamMPO, PsiSize);
+   };
+
+   std::vector<std::vector<SimpleOperator>> EvenU;
+   std::complex<double> EvenTime = StepStart;
+   for (double x : decomp.a())
+   {
+      std::complex<double> SliceTimestep = x * Timestep;
+      EvenU.push_back(AssembleFiniteTEBDEvenSlice(HamiltonianSlice(EvenTime, SliceTimestep), SliceTimestep));
+      EvenTime += SliceTimestep;
+   }
+
+   std::vector<std::vector<SimpleOperator>> OddU;
+   std::complex<double> OddTime = StepStart;
+   for (double x : decomp.b())
+   {
+      std::complex<double> SliceTimestep = x * Timestep;
+      OddU.push_back(AssembleFiniteTEBDOddSlice(HamiltonianSlice(OddTime, SliceTimestep), SliceTimestep));
+      OddTime += SliceTimestep;
+   }
+
+   std::vector<SimpleOperator> EvenContinuation;
+   if (decomp.a().size() == decomp.b().size()+1)
+   {
+      std::complex<double> SliceStart = StepStart - decomp.a().back() * Timestep;
+      std::complex<double> SliceTimestep = (decomp.a().back() + decomp.a().front()) * Timestep;
+      EvenContinuation = AssembleFiniteTEBDEvenSlice(HamiltonianSlice(SliceStart, SliceTimestep), SliceTimestep);
+   }
+
+   return {EvenU, OddU, EvenContinuation};
+}
+
+BasicTriangularMPO
+PreparePeriodicTEBDHamiltonianUnitCell(BasicTriangularMPO HamMPO, int Coarsegrain, int PsiSize)
+{
+   HamMPO = coarse_grain(HamMPO, Coarsegrain);
+
+   int UnitCellSize = statistics::lcm(PsiSize, HamMPO.size(), 2);
+   return repeat(HamMPO, UnitCellSize / HamMPO.size());
+}
+
+std::vector<SimpleOperator>
+PeriodicTEBDBondHamiltonian(BasicTriangularMPO const& HamMPO)
+{
+   int UnitCellSize = HamMPO.size();
+
+   std::vector<SimpleOperator> BondH(UnitCellSize);
+   auto SplitTerms = SplitMPO(HamMPO);
+   for (int i = 0; i < SplitTerms.size(); ++i)
+   {
+      for (auto const& op : SplitTerms[i])
+      {
+         if (op.size() == 1)
+         {
+            // Split single-site operators over the two bonds, wrapping around the unit cell.
+            SimpleRedOperator p = tensor_prod(op[0](0,0), HamMPO[(i+1)%UnitCellSize](0,0));
+            BondH[i] += 0.5 * p.scalar();
+            SimpleRedOperator q = tensor_prod(HamMPO[(i+UnitCellSize-1)%UnitCellSize](0,0), op[0](0,0));
+            BondH[(i+UnitCellSize-1)%UnitCellSize] += 0.5 * q.scalar();
+         }
+         else if (op.size() == 2)
+         {
+            BondH[i] += coarse_grain(op).scalar();
+         }
+         else
+         {
+            throw std::runtime_error("fatal: operator has support over more than 2 sites.");
+         }
+      }
+   }
+
+   return BondH;
+}
+
+std::vector<SimpleOperator>
+AssemblePeriodicTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
+                              std::complex<double> SliceTimestep)
+{
+   int UnitCellSize = HamMPO.size();
+   std::vector<SimpleOperator> BondH = PeriodicTEBDBondHamiltonian(HamMPO);
+   std::vector<SimpleOperator> Terms;
+   for (int i = 0; i < BondH.size(); i += 2)
+   {
+      Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
+                                           HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
+   }
+   return Terms;
+}
+
+std::vector<SimpleOperator>
+AssemblePeriodicTEBDOddSlice(BasicTriangularMPO const& HamMPO,
+                             std::complex<double> SliceTimestep)
+{
+   int UnitCellSize = HamMPO.size();
+   std::vector<SimpleOperator> BondH = PeriodicTEBDBondHamiltonian(HamMPO);
+   std::vector<SimpleOperator> Terms;
+
+   // The odd slice uses a rotation of the unit cell that takes the right-most site and puts it on the left.
+   Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[BondH.size()-1],
+                                        HamMPO[BondH.size()-1], HamMPO[0]));
+   for (int i = 1; i < BondH.size()-1; i += 2)
+   {
+      Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
+                                           HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
+   }
+
+   return Terms;
+}
+
+TEBDHamiltonianGates
+AssemblePeriodicTEBDHamiltonian(BasicTriangularMPO const& HamMPO,
+                                std::complex<double> Timestep,
+                                LTSDecomposition const& decomp)
+{
+   int UnitCellSize = HamMPO.size();
+   std::vector<SimpleOperator> BondH = PeriodicTEBDBondHamiltonian(HamMPO);
+
+   std::vector<std::vector<SimpleOperator>> EvenU;
+   for (auto x : decomp.a())
+   {
+      std::vector<SimpleOperator> Terms;
+      for (int i = 0; i < BondH.size(); i += 2)
+      {
+         Terms.push_back(ExponentiateTEBDBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                              HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
+      }
+      EvenU.push_back(std::move(Terms));
+   }
+
+   std::vector<std::vector<SimpleOperator>> OddU;
+   for (auto x : decomp.b())
+   {
+      std::vector<SimpleOperator> Terms;
+      Terms.push_back(ExponentiateTEBDBond(-Timestep*std::complex<double>(0,x), BondH[BondH.size()-1],
+                                           HamMPO[BondH.size()-1], HamMPO[0]));
+      for (int i = 1; i < BondH.size()-1; i += 2)
+      {
+         Terms.push_back(ExponentiateTEBDBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                              HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
+      }
+      OddU.push_back(std::move(Terms));
+   }
+
+   std::vector<SimpleOperator> EvenContinuation;
+   if (decomp.a().size() == decomp.b().size()+1)
+   {
+      double x = decomp.a().front() + decomp.a().back();
+      for (int i = 0; i < BondH.size(); i += 2)
+      {
+         EvenContinuation.push_back(ExponentiateTEBDBond(-Timestep*std::complex<double>(0,x), BondH[i],
+                                                         HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
+      }
+   }
+
+   return {EvenU, OddU, EvenContinuation};
+}
+
+TEBDHamiltonianGates
+AssemblePeriodicTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
+                                             std::string const& HamOperator,
+                                             std::string const& TimeVar,
+                                             std::complex<double> StepStart,
+                                             std::complex<double> Timestep,
+                                             LTSDecomposition const& decomp,
+                                             int MagnusOrder,
+                                             int MagnusQuadrature,
+                                             int Coarsegrain,
+                                             int PsiSize)
+{
+   auto HamiltonianSlice = [&](std::complex<double> SliceStart, std::complex<double> SliceTimestep)
+   {
+      BasicTriangularMPO HamMPO = TimeDependentHamiltonianMPO(Lattice, HamOperator, TimeVar,
+                                                              SliceStart, SliceTimestep,
+                                                              MagnusOrder, MagnusQuadrature);
+      return PreparePeriodicTEBDHamiltonianUnitCell(HamMPO, Coarsegrain, PsiSize);
+   };
+
+   std::vector<std::vector<SimpleOperator>> EvenU;
+   std::complex<double> EvenTime = StepStart;
+   for (double x : decomp.a())
+   {
+      std::complex<double> SliceTimestep = x * Timestep;
+      EvenU.push_back(AssemblePeriodicTEBDEvenSlice(HamiltonianSlice(EvenTime, SliceTimestep), SliceTimestep));
+      EvenTime += SliceTimestep;
+   }
+
+   std::vector<std::vector<SimpleOperator>> OddU;
+   std::complex<double> OddTime = StepStart;
+   for (double x : decomp.b())
+   {
+      std::complex<double> SliceTimestep = x * Timestep;
+      OddU.push_back(AssemblePeriodicTEBDOddSlice(HamiltonianSlice(OddTime, SliceTimestep), SliceTimestep));
+      OddTime += SliceTimestep;
+   }
+
+   std::vector<SimpleOperator> EvenContinuation;
+   if (decomp.a().size() == decomp.b().size()+1)
+   {
+      std::complex<double> SliceStart = StepStart - decomp.a().back() * Timestep;
+      std::complex<double> SliceTimestep = (decomp.a().back() + decomp.a().front()) * Timestep;
+      EvenContinuation = AssemblePeriodicTEBDEvenSlice(HamiltonianSlice(SliceStart, SliceTimestep), SliceTimestep);
+   }
+
+   return {EvenU, OddU, EvenContinuation};
+}
 
 LinearAlgebra::DiagonalMatrix<double>
 InvertDiagonal(LinearAlgebra::DiagonalMatrix<double> const& D, double Tol = 1E-15)

--- a/mp-algorithms/tebd.cpp
+++ b/mp-algorithms/tebd.cpp
@@ -164,6 +164,17 @@ ExponentiateTEBDBond(std::complex<double> Factor,
    return Exponentiate(Factor * BondTerm);
 }
 
+void
+CheckTEBDSplitFamilyClock(std::complex<double> Clock,
+                          std::complex<double> ExpectedEnd,
+                          char const* Family)
+{
+   double const Scale = std::max(1.0, std::max(std::abs(Clock), std::abs(ExpectedEnd)));
+   CHECK(std::abs(Clock - ExpectedEnd) <= 1e-12 * Scale)
+      ("TEBD split-family clock does not cover exactly one timestep")
+      (Family)(Clock)(ExpectedEnd);
+}
+
 BasicTriangularMPO
 PrepareFiniteTEBDHamiltonian(BasicTriangularMPO HamMPO, int PsiSize)
 {
@@ -318,6 +329,10 @@ AssembleFiniteTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
       OddU.push_back(AssembleFiniteTEBDOddSlice(HamiltonianSlice(OddTime, SliceTimestep), SliceTimestep));
       OddTime += SliceTimestep;
    }
+
+   std::complex<double> const StepEnd = StepStart + Timestep;
+   CheckTEBDSplitFamilyClock(EvenTime, StepEnd, "even");
+   CheckTEBDSplitFamilyClock(OddTime, StepEnd, "odd");
 
    std::vector<SimpleOperator> EvenContinuation;
    if (decomp.a().size() == decomp.b().size()+1)
@@ -498,6 +513,10 @@ AssemblePeriodicTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
       OddU.push_back(AssemblePeriodicTEBDOddSlice(HamiltonianSlice(OddTime, SliceTimestep), SliceTimestep));
       OddTime += SliceTimestep;
    }
+
+   std::complex<double> const StepEnd = StepStart + Timestep;
+   CheckTEBDSplitFamilyClock(EvenTime, StepEnd, "even");
+   CheckTEBDSplitFamilyClock(OddTime, StepEnd, "odd");
 
    std::vector<SimpleOperator> EvenContinuation;
    if (decomp.a().size() == decomp.b().size()+1)

--- a/mp-algorithms/tebd.cpp
+++ b/mp-algorithms/tebd.cpp
@@ -239,18 +239,32 @@ FiniteTEBDBondHamiltonian(BasicTriangularMPO const& HamMPO)
    return BondH;
 }
 
-std::vector<SimpleOperator>
-AssembleFiniteTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
-                            std::complex<double> SliceTimestep)
+namespace
 {
-   std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDSlice(BasicTriangularMPO const& HamMPO,
+                        std::vector<SimpleOperator> const& BondH,
+                        int FirstBond,
+                        std::complex<double> SliceTimestep)
+{
    std::vector<SimpleOperator> Terms;
-   for (int i = 0; i < BondH.size(); i += 2)
+   for (int i = FirstBond; i < BondH.size(); i += 2)
    {
       Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
                                            HamMPO[i], HamMPO[i+1]));
    }
    return Terms;
+}
+
+} // namespace
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
+                            std::complex<double> SliceTimestep)
+{
+   std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
+   return AssembleFiniteTEBDSlice(HamMPO, BondH, 0, SliceTimestep);
 }
 
 std::vector<SimpleOperator>
@@ -258,13 +272,7 @@ AssembleFiniteTEBDOddSlice(BasicTriangularMPO const& HamMPO,
                            std::complex<double> SliceTimestep)
 {
    std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
-   std::vector<SimpleOperator> Terms;
-   for (int i = 1; i < BondH.size(); i += 2)
-   {
-      Terms.push_back(ExponentiateTEBDBond(-SliceTimestep*std::complex<double>(0.0, 1.0), BondH[i],
-                                           HamMPO[i], HamMPO[i+1]));
-   }
-   return Terms;
+   return AssembleFiniteTEBDSlice(HamMPO, BondH, 1, SliceTimestep);
 }
 
 TEBDHamiltonianGates
@@ -272,17 +280,20 @@ AssembleFiniteTEBDHamiltonian(BasicTriangularMPO const& HamMPO,
                               std::complex<double> Timestep,
                               LTSDecomposition const& decomp)
 {
+   std::vector<SimpleOperator> BondH = FiniteTEBDBondHamiltonian(HamMPO);
+
    std::vector<std::vector<SimpleOperator>> EvenU;
    for (auto x : decomp.a())
-      EvenU.push_back(AssembleFiniteTEBDEvenSlice(HamMPO, x*Timestep));
+      EvenU.push_back(AssembleFiniteTEBDSlice(HamMPO, BondH, 0, x*Timestep));
 
    std::vector<std::vector<SimpleOperator>> OddU;
    for (auto x : decomp.b())
-      OddU.push_back(AssembleFiniteTEBDOddSlice(HamMPO, x*Timestep));
+      OddU.push_back(AssembleFiniteTEBDSlice(HamMPO, BondH, 1, x*Timestep));
 
    std::vector<SimpleOperator> EvenContinuation;
    if (decomp.a().size() == decomp.b().size()+1)
-      EvenContinuation = AssembleFiniteTEBDEvenSlice(HamMPO, (decomp.a().front() + decomp.a().back()) * Timestep);
+      EvenContinuation = AssembleFiniteTEBDSlice(HamMPO, BondH, 0,
+                                                 (decomp.a().front() + decomp.a().back()) * Timestep);
 
    return {EvenU, OddU, EvenContinuation};
 }

--- a/mp-algorithms/tebd.cpp
+++ b/mp-algorithms/tebd.cpp
@@ -167,6 +167,13 @@ ExponentiateTEBDBond(std::complex<double> Factor,
 BasicTriangularMPO
 PrepareFiniteTEBDHamiltonian(BasicTriangularMPO HamMPO, int PsiSize)
 {
+   CHECK(!HamMPO.empty())("Finite TEBD Hamiltonian MPO is empty");
+   CHECK(HamMPO.size() <= PsiSize)("Finite TEBD Hamiltonian is larger than the wavefunction")
+      (HamMPO.size())(PsiSize);
+   CHECK(PsiSize % HamMPO.size() == 0)
+      ("Finite TEBD wavefunction size must be a multiple of the Hamiltonian unit cell")
+      (PsiSize)(HamMPO.size());
+
    if (HamMPO.size() < PsiSize)
       HamMPO = repeat(HamMPO, PsiSize / HamMPO.size());
    return HamMPO;

--- a/mp-algorithms/tebd.h
+++ b/mp-algorithms/tebd.h
@@ -21,9 +21,12 @@
 #if !defined(MTOOLKIT_MP_ALGORITHMS_TEBD_H)
 #define MTOOLKIT_MP_ALGORITHMS_TEBD_H
 
+#include <complex>
 #include <string>
 #include <vector>
 #include <map>
+#include "lattice/infinitelattice.h"
+#include "mpo/basic_triangular_mpo.h"
 #include "mps/state_component.h"
 #include "mps/truncation.h"
 
@@ -56,6 +59,85 @@ class LTSDecomposition
 
 // The list of all available decompositions.  See tebd.cpp for the complete list
 extern std::map<std::string, LTSDecomposition> Decompositions;
+
+struct TEBDHamiltonianGates
+{
+   std::vector<std::vector<SimpleOperator>> EvenU;
+   std::vector<std::vector<SimpleOperator>> OddU;
+   std::vector<SimpleOperator> EvenContinuation;
+};
+
+SimpleOperator
+TEBDBondIdentity(OperatorComponent const& Left, OperatorComponent const& Right);
+
+SimpleOperator
+ExponentiateTEBDBond(std::complex<double> Factor,
+                     SimpleOperator const& BondTerm,
+                     OperatorComponent const& Left,
+                     OperatorComponent const& Right);
+
+BasicTriangularMPO
+PrepareFiniteTEBDHamiltonian(BasicTriangularMPO HamMPO, int PsiSize);
+
+std::vector<SimpleOperator>
+FiniteTEBDBondHamiltonian(BasicTriangularMPO const& HamMPO);
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
+                            std::complex<double> SliceTimestep);
+
+std::vector<SimpleOperator>
+AssembleFiniteTEBDOddSlice(BasicTriangularMPO const& HamMPO,
+                           std::complex<double> SliceTimestep);
+
+TEBDHamiltonianGates
+AssembleFiniteTEBDHamiltonian(BasicTriangularMPO const& HamMPO,
+                              std::complex<double> Timestep,
+                              LTSDecomposition const& decomp);
+
+TEBDHamiltonianGates
+AssembleFiniteTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
+                                           std::string const& HamOperator,
+                                           std::string const& TimeVar,
+                                           std::complex<double> StepStart,
+                                           std::complex<double> Timestep,
+                                           LTSDecomposition const& decomp,
+                                           int MagnusOrder,
+                                           int MagnusQuadrature,
+                                           int PsiSize);
+
+BasicTriangularMPO
+PreparePeriodicTEBDHamiltonianUnitCell(BasicTriangularMPO HamMPO,
+                                       int Coarsegrain,
+                                       int PsiSize);
+
+std::vector<SimpleOperator>
+PeriodicTEBDBondHamiltonian(BasicTriangularMPO const& HamMPO);
+
+std::vector<SimpleOperator>
+AssemblePeriodicTEBDEvenSlice(BasicTriangularMPO const& HamMPO,
+                              std::complex<double> SliceTimestep);
+
+std::vector<SimpleOperator>
+AssemblePeriodicTEBDOddSlice(BasicTriangularMPO const& HamMPO,
+                             std::complex<double> SliceTimestep);
+
+TEBDHamiltonianGates
+AssemblePeriodicTEBDHamiltonian(BasicTriangularMPO const& HamMPO,
+                                std::complex<double> Timestep,
+                                LTSDecomposition const& decomp);
+
+TEBDHamiltonianGates
+AssemblePeriodicTimeDependentTEBDHamiltonian(InfiniteLattice const& Lattice,
+                                             std::string const& HamOperator,
+                                             std::string const& TimeVar,
+                                             std::complex<double> StepStart,
+                                             std::complex<double> Timestep,
+                                             LTSDecomposition const& decomp,
+                                             int MagnusOrder,
+                                             int MagnusQuadrature,
+                                             int Coarsegrain,
+                                             int PsiSize);
 
 // Do a TEBD iteration.
 //

--- a/mp-algorithms/time-dependent-mpo.cpp
+++ b/mp-algorithms/time-dependent-mpo.cpp
@@ -28,6 +28,7 @@ namespace
 {
 
 std::complex<double> const I(0.0, 1.0);
+int const MaxImplementedMagnusOrder = 4;
 
 std::pair<double, double>
 LegendreAndDerivative(int Order, double x)
@@ -144,6 +145,9 @@ ValidateMagnusOrder(int MagnusOrder)
 {
    if (MagnusOrder < 2 || MagnusOrder % 2 != 0)
       throw std::runtime_error("Invalid Magnus order; expected a positive even integer.");
+   if (MagnusOrder > MaxImplementedMagnusOrder)
+      throw std::runtime_error("Magnus orders above " + std::to_string(MaxImplementedMagnusOrder)
+                               + " are not implemented yet.");
 }
 
 int
@@ -218,8 +222,7 @@ TimeDependentHamiltonianMPO(InfiniteLattice const& Lattice,
                             int MagnusOrder,
                             int MagnusQuadratureOrder)
 {
-   if (MagnusOrder > 4)
-      throw std::runtime_error("Magnus orders above four are not implemented yet.");
+   ValidateMagnusOrder(MagnusOrder);
 
    if (Timestep == 0.0)
       return ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, Time}});

--- a/mp-algorithms/time-dependent-mpo.cpp
+++ b/mp-algorithms/time-dependent-mpo.cpp
@@ -1,0 +1,251 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://mptoolkit.qusim.net/
+//
+// mp-algorithms/time-dependent-mpo.cpp
+//
+// Copyright (C) 2026 Ian McCulloch <ian@qusim.net>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Research publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#include "time-dependent-mpo.h"
+#include "lattice/infinite-parser.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace
+{
+
+std::complex<double> const I(0.0, 1.0);
+
+std::pair<double, double>
+LegendreAndDerivative(int Order, double x)
+{
+   if (Order == 0)
+      return {1.0, 0.0};
+   if (Order == 1)
+      return {x, 1.0};
+
+   double Pm2 = 1.0;
+   double Pm1 = x;
+   double P = Pm1;
+   for (int n = 2; n <= Order; ++n)
+   {
+      P = ((2*n-1) * x * Pm1 - (n-1) * Pm2) / n;
+      Pm2 = Pm1;
+      Pm1 = P;
+   }
+
+   double dP = Order * (x * P - Pm2) / (x*x - 1.0);
+   return {P, dP};
+}
+
+std::vector<std::vector<double>>
+LagrangeCoefficients(std::vector<double> const& Nodes)
+{
+   int const Order = Nodes.size();
+   std::vector<std::vector<double>> Coeff(Order, std::vector<double>(Order, 0.0));
+
+   for (int i = 0; i < Order; ++i)
+   {
+      std::vector<double> Poly(1, 1.0);
+      double Denom = 1.0;
+
+      for (int j = 0; j < Order; ++j)
+      {
+         if (i == j)
+            continue;
+
+         std::vector<double> NewPoly(Poly.size()+1, 0.0);
+         for (int k = 0; k < Poly.size(); ++k)
+         {
+            NewPoly[k] += -Nodes[j] * Poly[k];
+            NewPoly[k+1] += Poly[k];
+         }
+         Poly = std::move(NewPoly);
+         Denom *= Nodes[i] - Nodes[j];
+      }
+
+      for (int k = 0; k < Order; ++k)
+         Coeff[k][i] = Poly[k] / Denom;
+   }
+
+   return Coeff;
+}
+
+std::vector<std::vector<double>>
+CommutatorWeights(std::vector<double> const& Nodes,
+                  std::vector<double> const& Weights)
+{
+   int const Order = Nodes.size();
+   auto const Coeff = LagrangeCoefficients(Nodes);
+
+   std::vector<std::vector<double>> Q(Order, std::vector<double>(Order, 0.0));
+   for (int Row = 0; Row < Order; ++Row)
+   {
+      for (int Col = 0; Col < Order; ++Col)
+      {
+         double Power = Nodes[Row];
+         for (int Degree = 0; Degree < Order; ++Degree)
+         {
+            Q[Row][Col] += Coeff[Degree][Col] * Power / double(Degree+1);
+            Power *= Nodes[Row];
+         }
+      }
+   }
+
+   std::vector<std::vector<double>> Raw(Order, std::vector<double>(Order, 0.0));
+   for (int Row = 0; Row < Order; ++Row)
+      for (int Col = 0; Col < Order; ++Col)
+         Raw[Row][Col] = Weights[Row] * Q[Row][Col]
+                       - 0.5 * Weights[Row] * Weights[Col];
+
+   std::vector<std::vector<double>> Result(Order, std::vector<double>(Order, 0.0));
+   for (int Row = 0; Row < Order; ++Row)
+   {
+      for (int Col = 0; Col < Order; ++Col)
+      {
+         // Sign convention for the effective Hamiltonian.  For the two-point
+         // Gauss rule this gives Gamma_12 = sqrt(3)/12, matching the existing
+         // fourth-order implementation.
+         Result[Row][Col] = 0.5 * (Raw[Col][Row] - Raw[Row][Col]);
+      }
+      Result[Row][Row] = 0.0;
+   }
+
+   return Result;
+}
+
+BasicTriangularMPO
+WeightedSum(std::vector<BasicTriangularMPO> const& Operators,
+            std::vector<double> const& Weights)
+{
+   BasicTriangularMPO Result = Weights[0] * Operators[0];
+   for (int i = 1; i < Operators.size(); ++i)
+      Result += Weights[i] * Operators[i];
+   return Result;
+}
+
+} // namespace
+
+void
+ValidateMagnusOrder(int MagnusOrder)
+{
+   if (MagnusOrder < 2 || MagnusOrder % 2 != 0)
+      throw std::runtime_error("Invalid Magnus order; expected a positive even integer.");
+}
+
+int
+DefaultMagnusQuadratureOrder(int MagnusOrder)
+{
+   ValidateMagnusOrder(MagnusOrder);
+
+   return std::max(1, MagnusOrder / 2);
+}
+
+int
+ResolveMagnusQuadratureOrder(int MagnusOrder, int MagnusQuadratureOrder)
+{
+   ValidateMagnusOrder(MagnusOrder);
+
+   if (MagnusQuadratureOrder < 0)
+      throw std::runtime_error("Invalid Magnus quadrature order; expected a non-negative integer.");
+
+   int const Order = MagnusQuadratureOrder == 0
+      ? DefaultMagnusQuadratureOrder(MagnusOrder)
+      : MagnusQuadratureOrder;
+
+   if (Order < 1)
+      throw std::runtime_error("Invalid Magnus quadrature order; expected at least one point.");
+   if (MagnusOrder >= 4 && Order < 2)
+      throw std::runtime_error("Magnus orders of four or higher need at least two quadrature points.");
+
+   return Order;
+}
+
+MagnusQuadrature
+GaussLegendreMagnusQuadrature(int Order)
+{
+   if (Order < 1)
+      throw std::runtime_error("Invalid Gauss-Legendre quadrature order; expected at least one point.");
+
+   std::vector<double> Nodes(Order, 0.0);
+   std::vector<double> Weights(Order, 0.0);
+
+   double const Pi = std::acos(-1.0);
+   int const RootCount = (Order + 1) / 2;
+   for (int i = 0; i < RootCount; ++i)
+   {
+      double x = std::cos(Pi * (i + 0.75) / (Order + 0.5));
+      for (int Iter = 0; Iter < 50; ++Iter)
+      {
+         auto const [P, dP] = LegendreAndDerivative(Order, x);
+         double const dx = P / dP;
+         x -= dx;
+         if (std::abs(dx) <= 8.0 * std::numeric_limits<double>::epsilon() * std::max(1.0, std::abs(x)))
+            break;
+      }
+
+      double const dP = LegendreAndDerivative(Order, x).second;
+      double const Weight = 1.0 / ((1.0 - x*x) * dP * dP);
+
+      Nodes[i] = 0.5 * (1.0 - x);
+      Nodes[Order-1-i] = 0.5 * (1.0 + x);
+      Weights[i] = Weight;
+      Weights[Order-1-i] = Weight;
+   }
+
+   return {Nodes, Weights, CommutatorWeights(Nodes, Weights)};
+}
+
+BasicTriangularMPO
+TimeDependentHamiltonianMPO(InfiniteLattice const& Lattice,
+                            std::string const& HamOperator,
+                            std::string const& TimeVar,
+                            std::complex<double> Time,
+                            std::complex<double> Timestep,
+                            int MagnusOrder,
+                            int MagnusQuadratureOrder)
+{
+   if (MagnusOrder > 4)
+      throw std::runtime_error("Magnus orders above four are not implemented yet.");
+
+   if (Timestep == 0.0)
+      return ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, Time}});
+
+   int const QuadratureOrder = ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadratureOrder);
+   MagnusQuadrature const Quadrature = GaussLegendreMagnusQuadrature(QuadratureOrder);
+
+   std::vector<BasicTriangularMPO> Samples;
+   Samples.reserve(QuadratureOrder);
+   for (double Node : Quadrature.Nodes)
+      Samples.push_back(ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, Time + Node * Timestep}}));
+
+   BasicTriangularMPO Result = WeightedSum(Samples, Quadrature.Weights);
+
+   if (MagnusOrder >= 4)
+   {
+      for (int i = 0; i < QuadratureOrder; ++i)
+      {
+         for (int j = i+1; j < QuadratureOrder; ++j)
+         {
+            double const Gamma = Quadrature.CommutatorWeights[i][j];
+            if (Gamma != 0.0)
+               Result += (-I * Timestep * Gamma) * commutator(Samples[i], Samples[j]);
+         }
+      }
+   }
+
+   return Result;
+}

--- a/mp-algorithms/time-dependent-mpo.h
+++ b/mp-algorithms/time-dependent-mpo.h
@@ -1,0 +1,53 @@
+// -*- C++ -*-
+//----------------------------------------------------------------------------
+// Matrix Product Toolkit http://mptoolkit.qusim.net/
+//
+// mp-algorithms/time-dependent-mpo.h
+//
+// Copyright (C) 2026 Ian McCulloch <ian@qusim.net>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Research publications making use of this software should include
+// appropriate citations and acknowledgements as described in
+// the file CITATIONS in the main source directory.
+//----------------------------------------------------------------------------
+// ENDHEADER
+
+#if !defined(MPTOOLKIT_MP_ALGORITHMS_TIME_DEPENDENT_MPO_H)
+#define MPTOOLKIT_MP_ALGORITHMS_TIME_DEPENDENT_MPO_H
+
+#include "lattice/infinitelattice.h"
+#include "mpo/basic_triangular_mpo.h"
+#include <complex>
+#include <string>
+#include <vector>
+
+struct MagnusQuadrature
+{
+   std::vector<double> Nodes;
+   std::vector<double> Weights;
+   std::vector<std::vector<double>> CommutatorWeights;
+};
+
+void ValidateMagnusOrder(int MagnusOrder);
+
+int DefaultMagnusQuadratureOrder(int MagnusOrder);
+
+int ResolveMagnusQuadratureOrder(int MagnusOrder, int MagnusQuadratureOrder);
+
+MagnusQuadrature GaussLegendreMagnusQuadrature(int Order);
+
+BasicTriangularMPO
+TimeDependentHamiltonianMPO(InfiniteLattice const& Lattice,
+                            std::string const& HamOperator,
+                            std::string const& TimeVar,
+                            std::complex<double> Time,
+                            std::complex<double> Timestep,
+                            int MagnusOrder,
+                            int MagnusQuadratureOrder = 0);
+
+#endif

--- a/mp/mp-aux-algebra.cpp
+++ b/mp/mp-aux-algebra.cpp
@@ -26,9 +26,9 @@
 #include "common/terminal.h"
 #include "common/prog_options.h"
 #include "common/prog_opt_accum.h"
+#include "common/randutil.h"
 #include "common/environment.h"
 #include "common/stringutil.h"
-#include "common/unique.h"
 #include "interface/inittemp.h"
 #include "tensor/tensor_eigen.h"
 #include "lattice/unitcell.h"
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
          print_preamble(std::cout, argc, argv);
 
       if (!NoRandomPhase)
-         srand(ext::get_unique() % RAND_MAX);
+         randutil::seed(randutil::crypto_rand());
 
       // if the number of eigenvalues is specified but
       // the cutoff is not, then set the cutoff to zero

--- a/mp/mp-excitation-ansatz.cpp
+++ b/mp/mp-excitation-ansatz.cpp
@@ -22,8 +22,8 @@
 #include "common/prog_opt_accum.h"
 #include "common/prog_options.h"
 #include "common/rangelist.h"
+#include "common/randutil.h"
 #include "common/terminal.h"
-#include "common/unique.h"
 #include "interface/inittemp.h"
 #include "lattice/infinite-parser.h"
 #include "lattice/infinitelattice.h"
@@ -140,9 +140,9 @@ int main(int argc, char** argv)
 
       Settings.Verbose = Verbose;
 
-      unsigned int RandSeed = vm.count("seed") ? (vm["seed"].as<unsigned long>() % RAND_MAX)
-         : (ext::get_unique() % RAND_MAX);
-      srand(RandSeed);
+      unsigned int RandSeed = vm.count("seed") ? static_cast<unsigned int>(vm["seed"].as<unsigned long>())
+         : randutil::crypto_rand();
+      randutil::seed(RandSeed);
 
       mp_pheap::InitializeTempPHeap();
 

--- a/mp/mp-ibc-dmrg.cpp
+++ b/mp/mp-ibc-dmrg.cpp
@@ -48,8 +48,6 @@ int main(int argc, char** argv)
       bool TwoSite = false;
       int Verbose = 0;
       std::string CompositionStr = "secondorder";
-      std::string Magnus = "2";
-      std::string TimeVar = "t";
       std::string PreExpandAlgo = "rsvd";
       std::string PostExpandAlgo = "rsvd";
 
@@ -205,7 +203,7 @@ int main(int argc, char** argv)
          }
       }
 
-      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Magnus, TimeVar, Verbose);
+      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Verbose);
 
       // Get EvolutionWindowLeft/Right from the wavefunction attributes if they
       // weren't specified, or else set them to the window boundaries.

--- a/mp/mp-ibc-tdvp.cpp
+++ b/mp/mp-ibc-tdvp.cpp
@@ -52,8 +52,6 @@ int main(int argc, char** argv)
       int Verbose = 0;
       int OutputDigits = 0;
       std::string CompositionStr = "secondorder";
-      std::string Magnus = "2";
-      std::string TimeVar = "t";
       std::string PreExpandAlgo = "rsvd";
       std::string PostExpandAlgo = "rsvd";
 
@@ -169,12 +167,6 @@ int main(int argc, char** argv)
          return 1;
       }
 
-      if (Magnus != "2" && Magnus != "4")
-      {
-         std::cerr << "fatal: Invalid Magnus scheme." << std::endl;
-         return 1;
-      }
-
       Settings.PreExpansionAlgo = PreExpansionAlgorithm(PreExpandAlgo);
       Settings.PostExpansionAlgo = PostExpansionAlgorithm(PostExpandAlgo);
 
@@ -272,7 +264,7 @@ int main(int argc, char** argv)
          }
       }
 
-      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Magnus, TimeVar, Verbose);
+      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Verbose);
 
       // Get EvolutionWindowLeft/Right from the wavefunction attributes if they
       // weren't specified, or else set them to the window boundaries.

--- a/mp/mp-ibc-tdvp.cpp
+++ b/mp/mp-ibc-tdvp.cpp
@@ -25,6 +25,7 @@
 #include "lattice/infinite-parser.h"
 #include "lattice/infinitelattice.h"
 #include "mp-algorithms/ibc-tdvp.h"
+#include "mp-algorithms/time-dependent-mpo.h"
 #include "mp/copyright.h"
 #include "mpo/basic_triangular_mpo.h"
 #include "parser/number-parser.h"
@@ -52,6 +53,9 @@ int main(int argc, char** argv)
       int Verbose = 0;
       int OutputDigits = 0;
       std::string CompositionStr = "secondorder";
+      int MagnusOrder = 2;
+      int MagnusQuadrature = 0;
+      std::string TimeVar = "t";
       std::string PreExpandAlgo = "rsvd";
       std::string PostExpandAlgo = "rsvd";
 
@@ -112,6 +116,10 @@ int main(int argc, char** argv)
          ("ewright", prog_opt::value(&EvolutionWindowRight), "Rightmost site of the initial evolution window (wavefunction attribute \"EvolutionWindowRight\")")
          ("epsilon", prog_opt::bool_switch(&Settings.Epsilon), "Calculate the error measures Eps1SqSum and Eps2SqSum")
          ("composition,c", prog_opt::value(&CompositionStr), FormatDefault("Composition scheme", CompositionStr).c_str())
+         ("magnus", prog_opt::value(&MagnusOrder), FormatDefault("For time-dependent window Hamiltonians, use this order of the Magnus expansion", MagnusOrder).c_str())
+         ("magnus-quadrature", prog_opt::value(&MagnusQuadrature),
+          FormatDefault("Gauss-Legendre quadrature order for time-dependent window Magnus terms (0 selects the default for --magnus)", MagnusQuadrature).c_str())
+         ("timevar", prog_opt::value(&TimeVar), FormatDefault("The time variable for time-dependent window Hamiltonians", TimeVar).c_str())
          ("verbose,v", prog_opt_ext::accum_value(&Verbose), "Increase verbosity (can be used more than once)")
          ;
 
@@ -164,6 +172,16 @@ int main(int argc, char** argv)
       if (Settings.Comp.Order == 0)
       {
          std::cerr << "fatal: Invalid composition" << std::endl;
+         return 1;
+      }
+
+      try
+      {
+         ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+      }
+      catch (std::exception const& e)
+      {
+         std::cerr << "fatal: " << e.what() << std::endl;
          return 1;
       }
 
@@ -264,7 +282,8 @@ int main(int argc, char** argv)
          }
       }
 
-      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Verbose);
+      WindowHamiltonian Ham(HamStr, HamStrWindow, Psi.left().size(), Verbose,
+                            MagnusOrder, TimeVar, MagnusQuadrature);
 
       // Get EvolutionWindowLeft/Right from the wavefunction attributes if they
       // weren't specified, or else set them to the window boundaries.

--- a/mp/mp-idmrg-s3e.cpp
+++ b/mp/mp-idmrg-s3e.cpp
@@ -68,9 +68,9 @@
 #include "common/formatting.h"
 #include "common/prog_options.h"
 #include <fstream>
+#include "common/randutil.h"
 #include <iostream>
 #include "common/environment.h"
-#include "common/unique.h"
 #include "common/statistics.h"
 #include "common/prog_opt_accum.h"
 #include "mp-algorithms/gmres.h"
@@ -955,7 +955,6 @@ int main(int argc, char** argv)
       double MixFactor = 0.02;
       double RandomMixFactor = 0.0;
       bool NoFixedPoint = false;
-      bool NoOrthogonalize = false;
       bool Create = false;
       bool ExactDiag = false;
       double FidelityScale = 1.0;
@@ -1020,8 +1019,6 @@ int main(int argc, char** argv)
           "(useful for integer spin chains, can be used multiple times)")
          ("create,b", prog_opt::bool_switch(&NoFixedPoint),
           "Construct a new wavefunction from a random state or single-cell diagonalization")
-         ("no-orthogonalize", prog_opt::bool_switch(&NoOrthogonalize),
-          "Don't orthogonalize the wavefunction before saving")
          ("maxiter", prog_opt::value<int>(&NumIter),
           FormatDefault("Maximum number of Lanczos iterations per step (Krylov subspace size)", NumIter).c_str())
          ("miniter", prog_opt::value<int>(&MinIter),
@@ -1078,9 +1075,9 @@ int main(int argc, char** argv)
       std::cout << "Starting iDMRG.  Hamiltonian = " << HamStr << '\n';
       std::cout << "Wavefunction = " << FName << std::endl;
 
-      unsigned int RandSeed = vm.count("seed") ? (vm["seed"].as<unsigned long>() % RAND_MAX)
-         : (ext::get_unique() % RAND_MAX);
-      srand(RandSeed);
+      unsigned int RandSeed = vm.count("seed") ? static_cast<unsigned int>(vm["seed"].as<unsigned long>())
+         : randutil::crypto_rand();
+      randutil::seed(RandSeed);
 
       if (vm.count("one-site"))
          TwoSite = !OneSite;

--- a/mp/mp-itdvp.cpp
+++ b/mp/mp-itdvp.cpp
@@ -23,6 +23,7 @@
 #include "common/terminal.h"
 #include "interface/inittemp.h"
 #include "mp-algorithms/itdvp.h"
+#include "mp-algorithms/time-dependent-mpo.h"
 #include "mp/copyright.h"
 #include "mpo/basic_triangular_mpo.h"
 #include "parser/number-parser.h"
@@ -48,7 +49,8 @@ int main(int argc, char** argv)
       int Verbose = 0;
       int OutputDigits = 0;
       std::string CompositionStr = "secondorder";
-      std::string Magnus = "2";
+      int MagnusOrder = 2;
+      int MagnusQuadrature = 0;
       std::string TimeVar = "t";
       bool Normalize = false;
       bool NoNormalize = false;
@@ -103,7 +105,9 @@ int main(int argc, char** argv)
          ("epsilon", prog_opt::bool_switch(&Settings.Epsilon), "Calculate the error measures Eps1SqSum and Eps2SqSum")
          ("neps,N", prog_opt::value(&Settings.NEps), "Calculate EpsNSqSum up to N = NEps >= 3")
          ("composition,c", prog_opt::value(&CompositionStr), FormatDefault("Composition scheme", CompositionStr).c_str())
-         ("magnus", prog_opt::value(&Magnus), FormatDefault("For time-dependent Hamiltonians, use this variant of the Magnus expansion", Magnus).c_str())
+         ("magnus", prog_opt::value(&MagnusOrder), FormatDefault("For time-dependent Hamiltonians, use this order of the Magnus expansion", MagnusOrder).c_str())
+         ("magnus-quadrature", prog_opt::value(&MagnusQuadrature),
+          FormatDefault("Gauss-Legendre quadrature order for time-dependent Magnus terms (0 selects the default for --magnus)", MagnusQuadrature).c_str())
          ("timevar", prog_opt::value(&TimeVar), FormatDefault("The time variable for time-dependent Hamiltonians", TimeVar).c_str())
          ("normalize", prog_opt::bool_switch(&Normalize), "Normalize the wavefunction [default true if timestep is real]")
          ("nonormalize", prog_opt::bool_switch(&NoNormalize), "Don't normalize the wavefunction")
@@ -160,9 +164,13 @@ int main(int argc, char** argv)
          return 1;
       }
 
-      if (Magnus != "2" && Magnus != "4")
+      try
       {
-         std::cerr << "fatal: Invalid Magnus scheme." << std::endl;
+         ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+      }
+      catch (std::exception const& e)
+      {
+         std::cerr << "fatal: " << e.what() << std::endl;
          return 1;
       }
 
@@ -274,7 +282,7 @@ int main(int argc, char** argv)
          }
       }
 
-      Hamiltonian Ham(HamStr, Psi.size(), Magnus, TimeVar, Verbose);
+      Hamiltonian Ham(HamStr, Psi.size(), Verbose, MagnusOrder, TimeVar, MagnusQuadrature);
 
       std::cout << "Maximum number of Lanczos iterations: " << Settings.MaxIter << '\n';
       std::cout << "Error tolerance for the Lanczos evolution: " << Settings.ErrTol << '\n';

--- a/mp/mp-itebd.cpp
+++ b/mp/mp-itebd.cpp
@@ -19,6 +19,7 @@
 // ENDHEADER
 
 #include "mp-algorithms/tebd.h"
+#include "mp-algorithms/time-dependent-mpo.h"
 #include "mpo/basic_triangular_mpo.h"
 #include "wavefunction/infinitewavefunctionleft.h"
 #include "wavefunction/mpwavefunction.h"
@@ -33,7 +34,6 @@
 #include "common/environment.h"
 #include "interface/inittemp.h"
 #include "common/prog_options.h"
-#include "common/statistics.h"
 #include "lattice/infinite-parser.h"
 #include "common/formatting.h"
 #include <cctype>
@@ -121,108 +121,6 @@ void DoOddSlice(std::deque<StateComponent>& Psi,
    Lambda.pop_front();
 }
 
-struct HamiltonianGates
-{
-   std::vector<std::vector<SimpleOperator>> EvenU;
-   std::vector<std::vector<SimpleOperator>> OddU;
-   std::vector<SimpleOperator> EvenContinuation;
-};
-
-SimpleOperator BondIdentity(OperatorComponent const& Left, OperatorComponent const& Right)
-{
-   return tensor_prod(SimpleOperator::make_identity(Left.LocalBasis1()),
-                      SimpleOperator::make_identity(Right.LocalBasis1()));
-}
-
-SimpleOperator ExponentiateBond(std::complex<double> Factor,
-                                SimpleOperator const& BondTerm,
-                                OperatorComponent const& Left,
-                                OperatorComponent const& Right)
-{
-   if (BondTerm.is_null())
-      return BondIdentity(Left, Right);
-   return Exponentiate(Factor * BondTerm);
-}
-
-// Construct the 2-body gates from the Hamiltonian.
-// We assume that the Hamiltonian has already been converted to an appropriate size unit cell.
-HamiltonianGates AssembleHamiltonian(BasicTriangularMPO HamMPO, std::complex<double> Timestep, LTSDecomposition const& decomp)
-{
-   int UnitCellSize = HamMPO.size();
-
-   // Assemble the Hamiltonian into the bond terms
-   std::vector<SimpleOperator> BondH(UnitCellSize);
-   auto SplitTerms = SplitMPO(HamMPO);
-   for (int i = 0; i < SplitTerms.size(); ++i)
-   {
-      for (auto const& op : SplitTerms[i])
-      {
-         if (op.size() == 1)
-         {
-            // split single-site operators over the two bonds, if i=0 then
-            // the split wraps around the unit cell
-            SimpleRedOperator p = tensor_prod(op[0](0,0),HamMPO[(i+1)%UnitCellSize](0,0));
-            BondH[i] += 0.5 * p.scalar();
-            SimpleRedOperator q = tensor_prod(HamMPO[(i+UnitCellSize-1)%UnitCellSize](0,0), op[0](0,0));
-            BondH[(i+UnitCellSize-1)%UnitCellSize] += 0.5 * q.scalar();
-         }
-         else if (op.size() == 2)
-         {
-               BondH[i] += coarse_grain(op).scalar();
-         }
-         else
-         {
-            throw std::runtime_error("fatal: operator has support over more than 2 sites.");
-         }
-      }
-   }
-
-   // Exponentiate the bond operators and split into even and odd slices
-   std::vector<std::vector<SimpleOperator>> EvenU;
-   for (auto x : decomp.a())
-   {
-      std::vector<SimpleOperator> Terms;
-      for (int i = 0; i < BondH.size(); i += 2)
-      {
-         Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
-                                          HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
-      }
-      EvenU.push_back(std::move(Terms));
-   }
-
-   std::vector<std::vector<SimpleOperator>> OddU;
-   // The odd slice uses a rotation of the unit cell that takes the right-most site and puts it on the left.
-   // This means that the first odd-bond operator we need is the one that wraps around, which is at the end of the list.
-   // To allow for this, we reserve the first element of the Terms vector and move the last element to the front
-   for (auto x : decomp.b())
-   {
-      std::vector<SimpleOperator> Terms;
-      Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[BondH.size()-1],
-                                       HamMPO[BondH.size()-1], HamMPO[0]));
-      for (int i = 1; i < BondH.size()-1; i += 2)
-      {
-         Terms.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
-                                          HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
-      }
-      OddU.push_back(std::move(Terms));
-   }
-
-   // If we have an odd number of terms (the usual case), then we can wrap around the last even slice
-   // if we are continuing the evolution beyond the current timestep.  This is the sum of a[last] + a[0] terms
-   std::vector<SimpleOperator> EvenContinuation;
-   if (decomp.a().size() == decomp.b().size()+1)
-   {
-      double x = decomp.a().front() + decomp.a().back();
-      for (int i = 0; i < BondH.size(); i += 2)
-      {
-         EvenContinuation.push_back(ExponentiateBond(-Timestep*std::complex<double>(0,x), BondH[i],
-                                                     HamMPO[i], HamMPO[(i+1)%UnitCellSize]));
-      }
-   }
-
-   return {EvenU, OddU, EvenContinuation};
-}
-
 int main(int argc, char** argv)
 {
    try
@@ -246,7 +144,8 @@ int main(int argc, char** argv)
       double EigenCutoff = 1E-16;
       int OutputDigits = 0;
       int Coarsegrain = 1;
-      std::string Magnus = "2";
+      int MagnusOrder = 2;
+      int MagnusQuadrature = 0;
       std::string TimeVar = "t";
       std::string DecompositionStr = "optimized4-11";
       bool TimeDependent = false;
@@ -272,7 +171,9 @@ int main(int argc, char** argv)
           FormatDefault("Truncation error cutoff", TruncCutoff).c_str())
          ("eigen-cutoff,d", prog_opt::value(&EigenCutoff),
           FormatDefault("Cutoff threshold for density matrix eigenvalues", EigenCutoff).c_str())
-         ("magnus", prog_opt::value(&Magnus), FormatDefault("For time-dependent Hamiltonians, use this variant of the Magnus expansion", Magnus).c_str())
+         ("magnus", prog_opt::value(&MagnusOrder), FormatDefault("For time-dependent Hamiltonians, use this order of the Magnus expansion", MagnusOrder).c_str())
+         ("magnus-quadrature", prog_opt::value(&MagnusQuadrature),
+          FormatDefault("Gauss-Legendre quadrature order for time-dependent Magnus terms (0 selects the default for --magnus)", MagnusQuadrature).c_str())
          ("timevar", prog_opt::value(&TimeVar), FormatDefault("The time variable for time-dependent Hamiltonians", TimeVar).c_str())
          ("coarsegrain", prog_opt::value(&Coarsegrain), "coarse-grain N-to-1 sites")
          ("normalize", prog_opt::bool_switch(&Normalize), "Normalize the wavefunction [default if timestep is real]")
@@ -312,6 +213,16 @@ int main(int argc, char** argv)
       if (decomp.order() == 0)
       {
          std::cerr << "mp-itebd: fatal: invalid decomposition\n";
+         return 1;
+      }
+
+      try
+      {
+         ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+      }
+      catch (std::exception const& e)
+      {
+         std::cerr << "mp-itebd: fatal: " << e.what() << '\n';
          return 1;
       }
 
@@ -402,13 +313,8 @@ int main(int argc, char** argv)
       try
       {
          HamMPO = ParseTriangularOperator(Lattice, HamOperator);
-         //Coarse-grain, if necessary
-         HamMPO = coarse_grain(HamMPO, Coarsegrain);
-
-         // Make sure the unit cell is an even size
-         int UnitCellSize = statistics::lcm(Psi.size(), HamMPO.size(), 2);
-
-         HamMPO = repeat(HamMPO, UnitCellSize / HamMPO.size());
+         HamMPO = PreparePeriodicTEBDHamiltonianUnitCell(HamMPO, Coarsegrain, Psi.size());
+         int UnitCellSize = HamMPO.size();
 
          // and adjust the wavefunction and hamiltonian to match the unit cell size
          if (Psi.size() != UnitCellSize)
@@ -430,10 +336,24 @@ int main(int argc, char** argv)
          throw;
       }
 
-      HamiltonianGates Gates;
+      if (TimeDependent)
+      {
+         BasicTriangularMPO InitialHamMPO = TimeDependentHamiltonianMPO(Lattice, HamOperator, TimeVar,
+                                                                        InitialTime, Timestep,
+                                                                        MagnusOrder, MagnusQuadrature);
+         InitialHamMPO = PreparePeriodicTEBDHamiltonianUnitCell(InitialHamMPO, Coarsegrain, Psi.size());
+         int UnitCellSize = InitialHamMPO.size();
+         if (Psi.size() != UnitCellSize)
+         {
+            std::cerr << "mp-itebd: warning: extending wavefunction unit cell to " << UnitCellSize << " sites.\n";
+            Psi = repeat(Psi, UnitCellSize / Psi.size());
+         }
+      }
+
+      TEBDHamiltonianGates Gates;
       if (!TimeDependent)
       {
-         Gates = AssembleHamiltonian(HamMPO, Timestep, decomp);
+         Gates = AssemblePeriodicTEBDHamiltonian(HamMPO, Timestep, decomp);
          if (Verbose > 0)
          {
             std::cout << "Number of even slices: " << Gates.EvenU.size() << '\n';
@@ -470,36 +390,14 @@ int main(int argc, char** argv)
 
       while (tstep < N)
       {
-         // If the Hamiltonian is time-dependent, we need to construct it now
+         // If the Hamiltonian is time-dependent, build the gates over the
+         // actual time interval covered by each Suzuki-Trotter slice.
          if (TimeDependent)
          {
-            if (Magnus == "2")
-            {
-               std::complex<double> t = InitialTime + (tstep+0.5)*Timestep;
-               HamMPO = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t}});
-            }
-            else if (Magnus == "4")
-            {
-               std::complex<double> t1 = InitialTime + (tstep + 0.5 - std::sqrt(3.0)/6.0)*Timestep;
-               std::complex<double> t2 = InitialTime + (tstep + 0.5 + std::sqrt(3.0)/6.0)*Timestep;
-               BasicTriangularMPO A1 = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t1}});
-               BasicTriangularMPO A2 = ParseTriangularOperator(Lattice, HamOperator, {{TimeVar, t2}});
-               HamMPO = 0.5 * (A1 + A2) - Timestep*std::complex<double>(0.0, 1.0)* (sqrt(3.0) / 12.0) * commutator(A1, A2);
-            }
-            else
-            {
-               std::cerr << "Unknown --magnus option\n";
-               return 1;
-            }
-            //Coarse-grain, if necessary
-            HamMPO = coarse_grain(HamMPO, Coarsegrain);
-
-            // Make sure the unit cell is an even size
-            int UnitCellSize = statistics::lcm(Psi.size(), HamMPO.size(), 2);
-
-            HamMPO = repeat(HamMPO, UnitCellSize / HamMPO.size());
-
-            Gates = AssembleHamiltonian(HamMPO, Timestep, decomp);
+            Gates = AssemblePeriodicTimeDependentTEBDHamiltonian(Lattice, HamOperator, TimeVar,
+                                                                 InitialTime + double(tstep)*Timestep, Timestep,
+                                                                 decomp, MagnusOrder, MagnusQuadrature,
+                                                                 Coarsegrain, Psi.size());
          }
 
          if (Continue)

--- a/mp/mp-tdvp.cpp
+++ b/mp/mp-tdvp.cpp
@@ -22,6 +22,7 @@
 #include "common/prog_options.h"
 #include "common/terminal.h"
 #include "interface/inittemp.h"
+#include "mp-algorithms/time-dependent-mpo.h"
 #include "mp-algorithms/tdvp.h"
 #include "mp/copyright.h"
 #include "mpo/basic_triangular_mpo.h"
@@ -49,7 +50,8 @@ int main(int argc, char** argv)
       int Verbose = 0;
       int OutputDigits = 0;
       std::string CompositionStr = "secondorder";
-      std::string Magnus = "2";
+      int MagnusOrder = 2;
+      int MagnusQuadrature = 0;
       std::string TimeVar = "t";
       std::string PreExpandAlgo = "rsvd";
       std::string PostExpandAlgo = "rsvd";
@@ -98,7 +100,9 @@ int main(int argc, char** argv)
          ("two-site,2", prog_opt::bool_switch(&TwoSite), "Use two-site TDVP")
          ("epsilon", prog_opt::bool_switch(&Settings.Epsilon), "Calculate the error measures Eps1SqSum and Eps2SqSum")
          ("composition,c", prog_opt::value(&CompositionStr), FormatDefault("Composition scheme", CompositionStr).c_str())
-         ("magnus", prog_opt::value(&Magnus), FormatDefault("For time-dependent Hamiltonians, use this variant of the Magnus expansion", Magnus).c_str())
+         ("magnus", prog_opt::value(&MagnusOrder), FormatDefault("For time-dependent Hamiltonians, use this order of the Magnus expansion", MagnusOrder).c_str())
+         ("magnus-quadrature", prog_opt::value(&MagnusQuadrature),
+          FormatDefault("Gauss-Legendre quadrature order for time-dependent Magnus terms (0 selects the default for --magnus)", MagnusQuadrature).c_str())
          ("timevar", prog_opt::value(&TimeVar), FormatDefault("The time variable for time-dependent Hamiltonians", TimeVar).c_str())
          ("verbose,v", prog_opt_ext::accum_value(&Verbose), "Increase verbosity (can be used more than once)")
          ;
@@ -153,9 +157,13 @@ int main(int argc, char** argv)
          return 1;
       }
 
-      if (Magnus != "2" && Magnus != "4")
+      try
       {
-         std::cerr << "fatal: Invalid Magnus scheme." << std::endl;
+         ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+      }
+      catch (std::exception const& e)
+      {
+         std::cerr << "fatal: " << e.what() << std::endl;
          return 1;
       }
 
@@ -257,7 +265,7 @@ int main(int argc, char** argv)
          }
       }
 
-      Hamiltonian Ham(HamStr, Psi.size(), Magnus, TimeVar, Verbose);
+      Hamiltonian Ham(HamStr, Psi.size(), Verbose, MagnusOrder, TimeVar, MagnusQuadrature);
 
       std::cout << "Maximum number of Lanczos iterations: " << Settings.MaxIter << '\n';
       std::cout << "Error tolerance for the Lanczos evolution: " << Settings.ErrTol << '\n';

--- a/mp/mp-tebd.cpp
+++ b/mp/mp-tebd.cpp
@@ -44,6 +44,38 @@
 
 namespace prog_opt = boost::program_options;
 
+namespace
+{
+
+bool
+ValidateFiniteTEBDHamiltonianSize(BasicTriangularMPO const& HamMPO, int PsiSize)
+{
+   if (HamMPO.empty())
+   {
+      std::cerr << "mp-tebd: fatal: Hamiltonian MPO is empty.\n";
+      return false;
+   }
+
+   if (HamMPO.size() > PsiSize)
+   {
+      std::cerr << "mp-tebd: fatal: Hamiltonian unit cell size " << HamMPO.size()
+                << " exceeds wavefunction length " << PsiSize << ".\n";
+      return false;
+   }
+
+   if (PsiSize % HamMPO.size() != 0)
+   {
+      std::cerr << "mp-tebd: fatal: wavefunction length " << PsiSize
+                << " must be an integer multiple of the Hamiltonian unit cell size "
+                << HamMPO.size() << ".\n";
+      return false;
+   }
+
+   return true;
+}
+
+} // namespace
+
 void DoEvenSlice(std::deque<StateComponent>& Psi,
                  std::deque<RealDiagonalOperator>& Lambda,
                  double& LogAmplitude,
@@ -332,6 +364,8 @@ int main(int argc, char** argv)
       try
       {
          HamMPO = ParseTriangularOperator(Lattice, HamOperator);
+         if (!ValidateFiniteTEBDHamiltonianSize(HamMPO, Psi.size()))
+            return 1;
          HamMPO = PrepareFiniteTEBDHamiltonian(HamMPO, Psi.size());
       }
       catch (Parser::ParserError& e)
@@ -351,6 +385,14 @@ int main(int argc, char** argv)
       if (!TimeDependent)
       {
          Gates = AssembleFiniteTEBDHamiltonian(HamMPO, Timestep, decomp);
+      }
+      else
+      {
+         BasicTriangularMPO InitialHamMPO = TimeDependentHamiltonianMPO(Lattice, HamOperator, TimeVar,
+                                                                        InitialTime, Timestep,
+                                                                        MagnusOrder, MagnusQuadrature);
+         if (!ValidateFiniteTEBDHamiltonianSize(InitialHamMPO, Psi.size()))
+            return 1;
       }
 
       std::cout << "Using decomposition " << DecompositionStr << '\n';

--- a/mp/mp-tebd.cpp
+++ b/mp/mp-tebd.cpp
@@ -19,6 +19,7 @@
 // ENDHEADER
 
 #include "mp-algorithms/tebd.h"
+#include "mp-algorithms/time-dependent-mpo.h"
 #include "mpo/basic_triangular_mpo.h"
 #include "wavefunction/infinitewavefunctionleft.h"
 #include "wavefunction/mpwavefunction.h"
@@ -36,7 +37,9 @@
 #include "lattice/infinite-parser.h"
 #include "interface/inittemp.h"
 #include "common/openmp.h"
+#include "common/formatting.h"
 #include "tensor/reducible.h"
+#include "parser/parser.h"
 #include <cctype>
 
 namespace prog_opt = boost::program_options;
@@ -158,7 +161,11 @@ int main(int argc, char** argv)
       double EigenCutoff = 1E-16;
       int OutputDigits = 0;
       int Coarsegrain = 1;
+      int MagnusOrder = 2;
+      int MagnusQuadrature = 0;
+      std::string TimeVar = "t";
       std::string DecompositionStr = "optimized4-11";
+      bool TimeDependent = false;
       bool Quiet = false;
 
       prog_opt::options_description desc("Allowed options", terminal::columns());
@@ -169,6 +176,7 @@ int main(int argc, char** argv)
          ("wavefunction,w", prog_opt::value(&InputFile), "input wavefunction")
          ("output,o", prog_opt::value(&OutputPrefix), "prefix for saving output files")
          ("timestep,t", prog_opt::value(&TimestepStr), "timestep (required)")
+         ("betastep,b", prog_opt::value(&BetastepStr), "betastep (alternative to timestep)")
          ("decomposition,c", prog_opt::value(&DecompositionStr), FormatDefault("choice of decomposition", DecompositionStr).c_str())
          ("num-timesteps,n", prog_opt::value(&N), FormatDefault("number of timesteps to calculate", N).c_str())
          ("save-timesteps,s", prog_opt::value(&SaveEvery), "save the wavefunction every s timesteps")
@@ -180,6 +188,10 @@ int main(int argc, char** argv)
           FormatDefault("Truncation error cutoff", TruncCutoff).c_str())
          ("eigen-cutoff,d", prog_opt::value(&EigenCutoff),
           FormatDefault("Cutoff threshold for density matrix eigenvalues", EigenCutoff).c_str())
+         ("magnus", prog_opt::value(&MagnusOrder), FormatDefault("For time-dependent Hamiltonians, use this order of the Magnus expansion", MagnusOrder).c_str())
+         ("magnus-quadrature", prog_opt::value(&MagnusQuadrature),
+          FormatDefault("Gauss-Legendre quadrature order for time-dependent Magnus terms (0 selects the default for --magnus)", MagnusQuadrature).c_str())
+         ("timevar", prog_opt::value(&TimeVar), FormatDefault("The time variable for time-dependent Hamiltonians", TimeVar).c_str())
          ("coarsegrain", prog_opt::value(&Coarsegrain),
           "coarse-grain N-to-1 sites")
          ("normalize", prog_opt::bool_switch(&Normalize), "Normalize the wavefunction [default if timestep is real]")
@@ -196,7 +208,7 @@ int main(int argc, char** argv)
       if (vm.count("help") > 0 || vm.count("wavefunction") < 1
           ||  (vm.count("timestep") < 1 && vm.count("betastep") < 1))
       {
-         print_copyright(std::cerr, "tools", "mp-itebd");
+         print_copyright(std::cerr, "tools", "mp-tebd");
          std::cerr << "usage: " << basename(argv[0]) << " [options]\n";
          std::cerr << desc << '\n';
          std::cerr << "Available decompositions:\n";
@@ -219,7 +231,17 @@ int main(int argc, char** argv)
       }
       if (decomp.order() == 0)
       {
-         std::cerr << "mp-itebd: fatal: invalid decomposition\n";
+         std::cerr << "mp-tebd: fatal: invalid decomposition\n";
+         return 1;
+      }
+
+      try
+      {
+         ResolveMagnusQuadratureOrder(MagnusOrder, MagnusQuadrature);
+      }
+      catch (std::exception const& e)
+      {
+         std::cerr << "mp-tebd: fatal: " << e.what() << '\n';
          return 1;
       }
 
@@ -300,90 +322,45 @@ int main(int argc, char** argv)
          }
       }
 
-      std::tie(HamMPO, Lattice) = ParseTriangularOperatorAndLattice(HamStr);
-      if (HamMPO.size() < Psi.size())
-      HamMPO = repeat(HamMPO, Psi.size() / HamMPO.size());
+      std::string HamOperator;
+      std::tie(HamOperator, Lattice) = ParseOperatorStringAndLattice(HamStr);
 
-      // Assemble the Hamiltonian into the bond terms
-      std::vector<SimpleOperator> BondH(HamMPO.size()-1);
-      auto SplitTerms = SplitMPO(HamMPO);
-      for (int i = 0; i < SplitTerms.size(); ++i)
+      // Attempt to convert the operator into an MPO.  If it works, then the
+      // Hamiltonian is time-independent.  If it fails, assume it failed because
+      // the time variable is not defined yet; other operator errors will be
+      // reported when the time-dependent MPO is built.
+      try
       {
-         for (auto const& op : SplitTerms[i])
+         HamMPO = ParseTriangularOperator(Lattice, HamOperator);
+         HamMPO = PrepareFiniteTEBDHamiltonian(HamMPO, Psi.size());
+      }
+      catch (Parser::ParserError& e)
+      {
+         if (Verbose > 1)
          {
-            if (op.size() == 1)
-            {
-               // split single-site operators over the two bonds, unless they are at the edge
-               if (i == 0)
-               {
-                  SimpleRedOperator p = tensor_prod(op[0](0,0),HamMPO[i+1](0,0));
-                  BondH[i] += p.scalar();
-               }
-               else if (i == HamMPO.size()-1)
-               {
-                  SimpleRedOperator p = tensor_prod(HamMPO[i-1](0,0), op[0](0,0));
-                  BondH[i-1] += p.scalar();
-               }
-               else
-               {
-                  SimpleRedOperator p = tensor_prod(op[0](0,0),HamMPO[i+1](0,0));
-                  BondH[i] += 0.5 * p.scalar();
-                  SimpleRedOperator q = tensor_prod(HamMPO[i-1](0,0), op[0](0,0));
-                  BondH[i-1] += 0.5 * q.scalar();
-               }
-            }
-            else if (op.size() == 2)
-            {
-               // ignore terms that cross beyond the unit cell boundary
-               if (i < HamMPO.size()-1)
-                  BondH[i] += coarse_grain(op).scalar();
-            }
-            else
-            {
-               throw std::runtime_error("fatal: operator has support over more than 2 sites.");
-            }
+            std::cerr << "Parser error converting the Hamiltonian to an MPO - assuming the Hamiltonian is time-dependent.\n";
          }
+         TimeDependent = true;
+      }
+      catch (...)
+      {
+         throw;
       }
 
-      std::vector<std::vector<SimpleOperator>> EvenU;
-      for (auto x : decomp.a())
+      TEBDHamiltonianGates Gates;
+      if (!TimeDependent)
       {
-         std::vector<SimpleOperator> Terms;
-         for (int i = 0; i < BondH.size(); i += 2)
-         {
-            Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
-         }
-         EvenU.push_back(std::move(Terms));
-      }
-
-      std::vector<std::vector<SimpleOperator>> OddU;
-      for (auto x : decomp.b())
-      {
-         std::vector<SimpleOperator> Terms;
-         for (int i = 1; i < BondH.size(); i += 2)
-         {
-            Terms.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
-         }
-         OddU.push_back(std::move(Terms));
-      }
-
-      // If we have an odd number of terms (the usual case), then we can wrap around the last even slice
-      // if we are continuing the evolution beyond the current timestep.  This is the sum of a[last] + a[0] terms
-      std::vector<SimpleOperator> EvenContinuation;
-      if (decomp.a().size() == decomp.b().size()+1)
-      {
-         double x = decomp.a().front() + decomp.a().back();
-          for (int i = 0; i < BondH.size(); i += 2)
-         {
-            EvenContinuation.push_back(Exponentiate(-Timestep*std::complex<double>(0,x) * BondH[i]));
-         }
+         Gates = AssembleFiniteTEBDHamiltonian(HamMPO, Timestep, decomp);
       }
 
       std::cout << "Using decomposition " << DecompositionStr << '\n';
       if (Verbose > 0)
       {
-         std::cout << "Number of even slices: " << EvenU.size() << '\n';
-         std::cout << "Number of odd slices: " << OddU.size() << '\n';
+         if (!TimeDependent)
+         {
+            std::cout << "Number of even slices: " << Gates.EvenU.size() << '\n';
+            std::cout << "Number of odd slices: " << Gates.OddU.size() << '\n';
+         }
       }
 
       StatesInfo SInfo;
@@ -419,28 +396,38 @@ int main(int argc, char** argv)
 
       while (tstep < N)
       {
+         // If the Hamiltonian is time-dependent, build the gates over the
+         // actual time interval covered by each Suzuki-Trotter slice.
+         if (TimeDependent)
+         {
+            Gates = AssembleFiniteTimeDependentTEBDHamiltonian(Lattice, HamOperator, TimeVar,
+                                                               InitialTime + double(tstep)*Timestep, Timestep,
+                                                               decomp, MagnusOrder, MagnusQuadrature,
+                                                               Psi.size());
+         }
+
          if (Continue)
          {
             if (Verbose > 1)
             {
                std::cout << "Merge slice\n";
             }
-            DoEvenSlice(PsiVec, Lambda, LogAmplitude, EvenContinuation, SInfo, Verbose);
+            DoEvenSlice(PsiVec, Lambda, LogAmplitude, Gates.EvenContinuation, SInfo, Verbose);
          }
          else
          {
-            DoEvenSlice(PsiVec, Lambda, LogAmplitude, EvenU[0], SInfo, Verbose);
+            DoEvenSlice(PsiVec, Lambda, LogAmplitude, Gates.EvenU[0], SInfo, Verbose);
          }
 
-         DoOddSlice(PsiVec, Lambda, LogAmplitude, OddU[0], SInfo, Verbose);
-         for (int bi = 1; bi < OddU.size(); ++bi)
+         DoOddSlice(PsiVec, Lambda, LogAmplitude, Gates.OddU[0], SInfo, Verbose);
+         for (int bi = 1; bi < Gates.OddU.size(); ++bi)
          {
-            DoEvenSlice(PsiVec, Lambda, LogAmplitude, EvenU[bi], SInfo, Verbose);
-            DoOddSlice(PsiVec, Lambda, LogAmplitude, OddU[bi], SInfo, Verbose);
+            DoEvenSlice(PsiVec, Lambda, LogAmplitude, Gates.EvenU[bi], SInfo, Verbose);
+            DoOddSlice(PsiVec, Lambda, LogAmplitude, Gates.OddU[bi], SInfo, Verbose);
          }
 
          // do we do a continuation?
-         Continue = EvenU.size() > OddU.size();
+         Continue = Gates.EvenU.size() > Gates.OddU.size();
 
          ++tstep;
          std::cout << "Timestep " << formatting::format_complex(tstep)
@@ -451,15 +438,15 @@ int main(int argc, char** argv)
          {
             LinearWavefunction Psi;
             double ThisLogAmplitude = LogAmplitude;
-            if (EvenU.size() > OddU.size())
+            if (Gates.EvenU.size() > Gates.OddU.size())
             {
-               CHECK_EQUAL(EvenU.size(), OddU.size()+1);
+               CHECK_EQUAL(Gates.EvenU.size(), Gates.OddU.size()+1);
                std::cout << "Doing final slice before saving wavefunction.\n";
                // do the final slice to finish the timstep.  Make a copy of the wavefunction since it is better to
                // avoid a truncation step and 'continue' the wavefunction by wrapping around the next timestep.
                std::deque<StateComponent> PsiVecSave = PsiVec;
                std::deque<RealDiagonalOperator> LambdaSave = Lambda;
-               DoEvenSlice(PsiVecSave, LambdaSave, ThisLogAmplitude, EvenU.back(), SInfo, Verbose);
+               DoEvenSlice(PsiVecSave, LambdaSave, ThisLogAmplitude, Gates.EvenU.back(), SInfo, Verbose);
                Psi = LinearWavefunction::FromContainer(PsiVecSave.begin(), PsiVecSave.end());
             }
             else

--- a/tests/recipes/mptoolkit-probes.yaml
+++ b/tests/recipes/mptoolkit-probes.yaml
@@ -27,6 +27,13 @@ recipes:
     probe: mp-info {state}
     extract: full_text
 
+  info_log_amplitude:
+    probe: mp-info {state}
+    extract:
+      line_pattern:
+        pattern: "Log amplitude per unit cell = %(float:value)"
+        capture: value
+
   history_text:
     probe: mp-history {state}
     extract: full_text

--- a/tests/suites/ibc-tdvp-window-hamiltonian.yaml
+++ b/tests/suites/ibc-tdvp-window-hamiltonian.yaml
@@ -1,0 +1,1330 @@
+version: 0
+
+imports:
+  - ../recipes/mptoolkit-probes.yaml
+
+fixtures:
+  chain_lat:
+    run: spinchain-u1 -o lat
+    outputs:
+      lattice: lat
+
+  chain_neel2:
+    from: chain_lat
+    run: mp-construct -l lat -o psi 0.5:-0.5
+    outputs:
+      state: psi
+
+  chain_ibc:
+    from: chain_neel2
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  chain_ibc_window_i0:
+    from: chain_ibc
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 1"
+
+  chain_tdvp_td_window_support3:
+    from: chain_ibc_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:sum_unit(I(0))" -W "lat:tau*0*(I(0)+I(1)+I(2))" -o out -t 0-0.1i -n 1 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 5"
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
+  spin_plain_lat:
+    run: spinchain -o lat
+    outputs:
+      lattice: lat
+
+  spin_plain_up:
+    from: spin_plain_lat
+    run: mp-construct -l lat -o psi 0.5
+    outputs:
+      state: psi
+    certify:
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+
+  spin_plain_ibc:
+    from: spin_plain_up
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 0"
+
+  # Noncommuting time-dependent window Hamiltonian.  Since
+  # H_w(t)=cos(2t)Sx(0)+sin(2t)Sy(0), [H_w(t1),H_w(t2)] is nonzero
+  # for generic t1,t2.  The exact solution is still simple in the rotating
+  # frame: U(t)=exp(-2it Sz) exp(-it*(Sx-2Sz)).
+  # The listed observables are <psi|O|psi>/<psi|psi>, with
+  # psi = U(T)|up> and T equal to the final complex time.
+  spin_plain_rotating_time_dependent_window_real:
+    from: spin_plain_ibc
+    run: mp-ibc-tdvp -w ibc -H "lat:sum_unit(I(0))" -W "lat:cos(2*t)*Sx(0)+sin(2*t)*Sy(0)" --magnus 4 --magnus-quadrature 4 --timevar t -o out -t 0.01 -n 10 -s 10 -m 4 --min-states 1 --fidtol 1e-8 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.t0.10
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 5"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      # Exact rotating-frame result at T=0.1:
+      # psi = exp(-2i*T*Sz) exp(-i*T*(Sx-2*Sz)) |up>.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sx(0)"
+          approx: 0.004970945517723078
+          abs: 1e-7
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sy(0)"
+          approx: -0.04958520210779876
+          abs: 1e-7
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sz(0)"
+          approx: 0.4975103993210479
+          abs: 1e-7
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sz(-1)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  spin_plain_rotating_time_dependent_window_complex:
+    from: spin_plain_ibc
+    run: mp-ibc-tdvp -w ibc -H "lat:sum_unit(I(0))" -W "lat:cos(2*t)*Sx(0)+sin(2*t)*Sy(0)" --magnus 4 --magnus-quadrature 4 --timevar t -o out -t 0.01-0.005i -n 10 -s 10 -m 4 --min-states 1 --fidtol 1e-8 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.t0.100.b0.050
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 5"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.05
+          abs: 1e-12
+      # Exact rotating-frame result at T=0.1-0.05i:
+      # psi = exp(-2i*T*Sz) exp(-i*T*(Sx-2*Sz)) |up>, normalized for expectations.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sx(0)"
+          approx: -0.020770872100626184
+          abs: 1e-7
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sy(0)"
+          approx: -0.05471267530093071
+          abs: 1e-7
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Sz(0)"
+          approx: 0.4965632830099246
+          abs: 1e-7
+      - expectation_imag:
+          state: "{state}"
+          operator: "lat:Sx(0)"
+          approx: 0.0
+          abs: 1e-12
+
+  ladder_lat:
+    run: spinladder-u1 -o lat
+    outputs:
+      lattice: lat
+
+  ladder_neel4:
+    from: ladder_lat
+    run: mp-construct -l lat -o psi -r 2 0.5:-0.5
+    outputs:
+      state: psi
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Unit cell size = 4"
+
+  ladder_ibc:
+    from: ladder_neel4
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  ladder_ibc_window_i0:
+    from: ladder_ibc
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+
+  ladder_tdvp_td_window_support3:
+    from: ladder_ibc_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:sum_unit(I(0))" -W "lat:tau*0*(I(0)+I(1)+I(2))" -o out -t 0-0.1i -n 1 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 9"
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
+  cylinder_lat:
+    run: spincylinder-u1 -o lat
+    outputs:
+      lattice: lat
+
+  cylinder_neel4:
+    from: cylinder_lat
+    run: mp-construct -l lat -o psi 0.5:-0.5:0.5:-0.5
+    outputs:
+      state: psi
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Unit cell size = 4"
+
+  cylinder_ibc:
+    from: cylinder_neel4
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  cylinder_ibc_window_i0:
+    from: cylinder_ibc
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 4"
+
+  cylinder_tdvp_td_window_support2:
+    from: cylinder_ibc_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:sum_unit(I(0))" -W "lat:tau*0*(I(0)+I(1))" -o out -t 0-0.1i -n 1 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 10"
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
+  cylinder_neel8:
+    from: cylinder_lat
+    run: mp-construct -l lat -o psi -r 2 0.5:-0.5:0.5:-0.5
+    outputs:
+      state: psi
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Unit cell size = 8"
+
+  cylinder_ibc_uc8:
+    from: cylinder_neel8
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  cylinder_ibc_uc8_window_i0:
+    from: cylinder_ibc_uc8
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 4"
+
+  cylinder_uc8_tdvp_td_window_support3:
+    from: cylinder_ibc_uc8_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:sum_unit(I(0))" -W "lat:tau*0*(I(0)+I(1)+I(2))" -o out -t 0-0.1i -n 1 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 17"
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_y2_lat:
+    run: hubbardcylinder-u1su2 -y 2 -o lat
+    outputs:
+      lattice: lat
+
+  hubbard_y2_empty:
+    from: hubbard_y2_lat
+    run: mp-construct -l lat -o psi empty:empty
+    outputs:
+      state: psi
+
+  hubbard_y2_ibc:
+    from: hubbard_y2_empty
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  hubbard_y2_tdvp_empty_initial_window_operator:
+    from: hubbard_y2_ibc
+    run: mp-ibc-tdvp -w ibc -H "lat:H_t" -W "lat:I(-1)" -o out -t 0-0.1i -n 1 -s 1 -m 1 --pre none --post none
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 5"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:N(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Pdouble(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_y2_ibc_window_i0:
+    from: hubbard_y2_ibc
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = 0"
+
+  hubbard_y2_tdvp_window_spans_both_sides:
+    from: hubbard_y2_ibc_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:H_t" -W "lat:I(-1)+I(0)+I(1)" -o out -t 0-0.1i -n 1 -s 1 -m 1 --pre none --post none
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 8"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 3
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:N(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Pdouble(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_y2_tdvp_nexpand_keeps_offsets:
+    from: hubbard_y2_ibc_window_i0
+    run: mp-ibc-tdvp -w ibc_w -H "lat:H_t" -W "lat:I(0)" -o out -t 0-0.1i -n 1 -s 1 -m 1 --pre none --post none --n-expand 1
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:N(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Pdouble(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_y2_ibc_window_i_minus1:
+    from: hubbard_y2_ibc
+    run: mp-ibc-apply --window "lat:I(-1)" ibc ibc_w
+    outputs:
+      state: ibc_w
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+
+  hubbard_y2_tdvp_negative_offset_operator_extension:
+    from: hubbard_y2_ibc_window_i_minus1
+    run: mp-ibc-tdvp -w ibc_w -H "lat:H_t" -W "lat:I(-1)+I(0)" -o out -t 0-0.1i -n 1 -s 1 -m 1 --pre none --post none
+    outputs:
+      state: out.b0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 1
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:N(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Pdouble(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_lat:
+    run: hubbard-u1u1 -o lat
+    outputs:
+      lattice: lat
+
+  hubbard_u1u1_chain_empty:
+    from: hubbard_u1u1_chain_lat
+    run: mp-construct -l lat -o psi empty
+    outputs:
+      state: psi
+
+  hubbard_u1u1_chain_ibc:
+    from: hubbard_u1u1_chain_empty
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  hubbard_u1u1_chain_single_up:
+    from: hubbard_u1u1_chain_ibc
+    run: mp-ibc-apply --window "lat:CHup(0)" ibc ibc_up
+    outputs:
+      state: ibc_up
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 1"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = 0"
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(0)"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_single_up_at_positive_site:
+    from: hubbard_u1u1_chain_ibc
+    run: mp-ibc-apply --window "lat:CHup(1)" ibc ibc_up_pos
+    outputs:
+      state: ibc_up_pos
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = 0"
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(1)"
+          approx: 0.0
+          abs: 1e-12
+
+  # Exact time-dependent window-Hamiltonian checks.  The static background is
+  # intentionally trivial; all nontrivial evolution is in the finite window MPO.
+  hubbard_u1u1_chain_time_dependent_window_bond_imag:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(0),Cup(1))-dot(Cup(0),CHup(1)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Exact two-state solution for H_window(tau) = -(1+tau)B.
+      # With timestep z, theta = z + z^2/2 and p1 = |sin(theta)|^2/(|cos(theta)|^2+|sin(theta)|^2).
+      # Here z = -0.02i, so theta = -0.0002-0.02i.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9996002265252472
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.0003997734747527452
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)+Nup(0)+Nup(1)+Nup(2)"
+          approx: 1.0
+          abs: 1e-12
+      # Particle number and spin sector are conserved; this sums over the full reported window.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(-1)+Ndown(0)+Ndown(1)+Ndown(2)"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_bond_positive_location:
+    from: hubbard_u1u1_chain_single_up_at_positive_site
+    run: mp-ibc-tdvp -w ibc_up_pos -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(1),Cup(2))-dot(Cup(1),CHup(2)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -1"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: 0
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 3
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Same exact two-state solution as above, translated to the positive bond (1,2).
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.9996002265252472
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(2)"
+          approx: 0.0003997734747527452
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)+Nup(1)+Nup(2)+Nup(3)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_bond_left_extension:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(-1),Cup(0))-dot(Cup(-1),CHup(0)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Same exact two-state solution, but the finite window Hamiltonian extends to the left.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9996002265252472
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)"
+          approx: 0.0003997734747527452
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-2)+Nup(-1)+Nup(0)+Nup(1)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_three_site_both_sides:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(-1),Cup(0))-dot(Cup(-1),CHup(0))+dot(CHup(0),Cup(1))-dot(Cup(0),CHup(1)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 7"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Exact three-site single-particle imaginary-time solution for the same
+      # integrated coupling theta = -0.0002-0.02i.  Diagonalize the 3x3 path
+      # adjacency A, apply exp(theta*A) to the middle-site basis vector, and
+      # normalize |amplitude|^2.  TDVP one-step error is kept below 1e-6 here;
+      # the two-site translated cases above are exact to roundoff.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)"
+          approx: 0.00039993328072220123
+          abs: 1e-6
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9992001334385556
+          abs: 1e-6
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.00039993328072220063
+          abs: 1e-6
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-2)+Nup(-1)+Nup(0)+Nup(1)+Nup(2)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_bond_real:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(0),Cup(1))-dot(Cup(0),CHup(1)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0.02 -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.t0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -1
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.02
+          abs: 1e-12
+      # Same exact two-state solution with z = 0.02, so theta = 0.0202.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9995920154958612
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.0004079845041388137
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)+Nup(0)+Nup(1)+Nup(2)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_bond_complex:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(0),Cup(1))-dot(Cup(0),CHup(1)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0.02-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.t0.02.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.02
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Same exact two-state solution with z = 0.02-0.02i, so theta = 0.02-0.0204i.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9991845144366752
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.0008154855633248414
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)+Nup(0)+Nup(1)+Nup(2)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_chain_time_dependent_window_bond_four_steps:
+    from: hubbard_u1u1_chain_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(0),Cup(1))-dot(Cup(0),CHup(1)))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 4 -s 4 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.08
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 6"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -2"
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.08
+          abs: 1e-12
+      # Same exact two-state solution with z = -0.08i, so theta = -0.0032-0.08i.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)"
+          approx: 0.9936574529888663
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)"
+          approx: 0.006342547011133706
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)+Nup(0)+Nup(1)+Nup(2)"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_lat:
+    run: hubbardcylinder-u1u1 -y 2 -o lat
+    outputs:
+      lattice: lat
+
+  hubbard_u1u1_y2_empty:
+    from: hubbard_u1u1_y2_lat
+    run: mp-construct -l lat -o psi empty:empty
+    outputs:
+      state: psi
+
+  hubbard_u1u1_y2_ibc:
+    from: hubbard_u1u1_y2_empty
+    run: mp-ibc-create psi -o ibc --boundary-lambda
+    outputs:
+      state: ibc
+
+  hubbard_u1u1_y2_single_up:
+    from: hubbard_u1u1_y2_ibc
+    run: mp-ibc-apply --window "lat:CHup(0)[0]" ibc ibc_up
+    outputs:
+      state: ibc_up
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = 0"
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[0]"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_single_up_boundary:
+    from: hubbard_u1u1_y2_ibc
+    run: mp-ibc-apply --window "lat:CHup(0)[1]" ibc ibc_up_boundary
+    outputs:
+      state: ibc_up_boundary
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 2"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = 0"
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[1]"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_boundary_time_dependent_window_bond_complex:
+    from: hubbard_u1u1_y2_single_up_boundary
+    run: mp-ibc-tdvp -w ibc_up_boundary -H "lat:sum_unit(I(0))" -W "lat:-(1+tau)*(dot(CHup(0)[1],Cup(1)[1])-dot(Cup(0)[1],CHup(1)[1]))" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0.02-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.t0.02.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 7"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -1"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: 0
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 4
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.02
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Same exact two-state solution as the chain complex-time case,
+      # but starting at site [1] so the finite bond crosses a unit-cell boundary.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[1]"
+          approx: 0.9991845144366752
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)[1]"
+          approx: 0.0008154855633248414
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[0]+Nup(1)[0]"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-1)[0]+Nup(-1)[1]+Nup(0)[0]+Nup(0)[1]+Nup(1)[0]+Nup(1)[1]+Nup(2)[0]"
+          approx: 1.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_single_up_hopping_expansion:
+    from: hubbard_u1u1_y2_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:H_txup" -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 5"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -1"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: 0
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # Exact two-state imaginary-time update for Beta = 0.02:
+      # x = tanh(Beta/2), p0 = 1/(1+x*x), p1 = x*x/(1+x*x).
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(0)[0]"
+          approx: 0.999900016663956
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(1)[0]"
+          approx: 9.998333604400482e-05
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(0)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_single_up_time_dependent_window:
+    from: hubbard_u1u1_y2_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:H_txup" -W "lat:tau*Nup(1)[0]" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 1 -s 1 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.02
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 9"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -3"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 4
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.02
+          abs: 1e-12
+      # The time-dependent local potential changes the dynamics but conserves
+      # total Nup and Ndown; these sums cover the full reported window.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-2)[1]+Nup(-1)[0]+Nup(-1)[1]+Nup(0)[0]+Nup(0)[1]+Nup(1)[0]+Nup(1)[1]+Nup(2)[0]+Nup(2)[1]"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(-2)[1]+Ndown(-1)[0]+Ndown(-1)[1]+Ndown(0)[0]+Ndown(0)[1]+Ndown(1)[0]+Ndown(1)[1]+Ndown(2)[0]+Ndown(2)[1]"
+          approx: 0.0
+          abs: 1e-12
+
+  hubbard_u1u1_y2_single_up_td_window_four_steps:
+    from: hubbard_u1u1_y2_single_up
+    run: mp-ibc-tdvp -w ibc_up -H "lat:H_txup" -W "lat:tau*Nup(1)[0]" --timevar tau --magnus 4 --magnus-quadrature 3 -o out -t 0-0.02i -n 4 -s 4 -m 2 --min-states 1 --fidtol 1e-6 --pre fullsvd --post fullsvd
+    outputs:
+      state: out.b0.08
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 12"
+      - info_text:
+          state: "{state}"
+          contains: "Offset of first site of the window = -5"
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowLeft
+          approx: -4
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: EvolutionWindowRight
+          approx: 5
+          abs: 1e-12
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.08
+          abs: 1e-12
+      # As above, the time-dependent potential conserves total particle number;
+      # these sums cover the full expanded window at beta=0.08.
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Nup(-3)[1]+Nup(-2)[0]+Nup(-2)[1]+Nup(-1)[0]+Nup(-1)[1]+Nup(0)[0]+Nup(0)[1]+Nup(1)[0]+Nup(1)[1]+Nup(2)[0]+Nup(2)[1]+Nup(3)[0]"
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          state: "{state}"
+          operator: "lat:Ndown(-3)[1]+Ndown(-2)[0]+Ndown(-2)[1]+Ndown(-1)[0]+Ndown(-1)[1]+Ndown(0)[0]+Ndown(0)[1]+Ndown(1)[0]+Ndown(1)[1]+Ndown(2)[0]+Ndown(2)[1]+Ndown(3)[0]"
+          approx: 0.0
+          abs: 1e-12
+
+tests:
+  chain_lattice_uc1_wavefunction_uc2_extends_for_three_site_window_operator:
+    use: chain_tdvp_td_window_support3
+    expect:
+      - info_text:
+          contains: "Window size = 5"
+
+  spin_plain_real_time_noncommuting_time_dependent_window_matches_rotating_frame_solution:
+    use: spin_plain_rotating_time_dependent_window_real
+    expect:
+      # Same rotating-frame formula as the fixture:
+      # psi = exp(-2i*T*Sz) exp(-i*T*(Sx-2*Sz)) |up>, T=0.1.
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.4975103993210479
+          abs: 1e-7
+
+  spin_plain_complex_time_noncommuting_time_dependent_window_matches_rotating_frame_solution:
+    use: spin_plain_rotating_time_dependent_window_complex
+    expect:
+      # Same rotating-frame formula as the fixture, with T=0.1-0.05i.
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: -0.020770872100626184
+          abs: 1e-7
+
+  ladder_lattice_uc2_wavefunction_uc4_extends_for_three_lattice_unit_cells:
+    use: ladder_tdvp_td_window_support3
+    expect:
+      - info_text:
+          contains: "Window size = 9"
+
+  cylinder_lattice_uc4_wavefunction_uc4_extends_for_two_cylinder_unit_cells:
+    use: cylinder_tdvp_td_window_support2
+    expect:
+      - info_text:
+          contains: "Window size = 10"
+
+  cylinder_lattice_uc4_wavefunction_uc8_extends_to_wavefunction_unit_cell_boundary:
+    use: cylinder_uc8_tdvp_td_window_support3
+    expect:
+      - info_text:
+          contains: "Window size = 17"
+
+  hubbard_y2_empty_initial_window_extends_for_window_operator:
+    use: hubbard_y2_tdvp_empty_initial_window_operator
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+
+  hubbard_y2_window_operator_spans_both_sides_and_observables_stay_vacuum:
+    use: hubbard_y2_tdvp_window_spans_both_sides
+    expect:
+      - info_text:
+          contains: "Offset of first site of the window = -3"
+
+  hubbard_y2_window_expansion_updates_evolution_offsets:
+    use: hubbard_y2_tdvp_nexpand_keeps_offsets
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+
+  hubbard_y2_negative_offset_extension_regression:
+    use: hubbard_y2_tdvp_negative_offset_operator_extension
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+
+  hubbard_u1u1_chain_unit_cell_one_imag_time_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_imag
+    expect:
+      # Two-site formula from the fixture: theta=z+z^2/2, z=-0.02i.
+      - expectation_real:
+          operator: "lat:Nup(1)"
+          approx: 0.0003997734747527452
+          abs: 1e-12
+
+  hubbard_u1u1_chain_positive_location_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_positive_location
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowRight
+          approx: 3
+          abs: 1e-12
+
+  hubbard_u1u1_chain_left_extension_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_left_extension
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowLeft
+          approx: -2
+          abs: 1e-12
+
+  hubbard_u1u1_chain_both_side_extension_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_three_site_both_sides
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowRight
+          approx: 2
+          abs: 1e-12
+
+  hubbard_u1u1_chain_unit_cell_one_real_time_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_real
+    expect:
+      # Two-site formula from the fixture: theta=z+z^2/2, z=0.02.
+      - expectation_real:
+          operator: "lat:Nup(1)"
+          approx: 0.0004079845041388137
+          abs: 1e-12
+
+  hubbard_u1u1_chain_unit_cell_one_complex_time_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_complex
+    expect:
+      # Two-site formula from the fixture: theta=z+z^2/2, z=0.02-0.02i.
+      - expectation_real:
+          operator: "lat:Nup(1)"
+          approx: 0.0008154855633248414
+          abs: 1e-12
+
+  hubbard_u1u1_chain_unit_cell_one_multi_step_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_chain_time_dependent_window_bond_four_steps
+    expect:
+      # Two-site formula from the fixture: theta=z+z^2/2, z=-0.08i.
+      - expectation_real:
+          operator: "lat:Nup(1)"
+          approx: 0.006342547011133706
+          abs: 1e-12
+
+  hubbard_u1u1_y2_single_particle_hopping_expands_and_spreads:
+    use: hubbard_u1u1_y2_single_up_hopping_expansion
+    expect:
+      # Two-site static hopping formula from the fixture:
+      # x=tanh(Beta/2), p1=x*x/(1+x*x), Beta=0.02.
+      - expectation_real:
+          operator: "lat:Nup(1)[0]"
+          approx: 9.998333604400482e-05
+          abs: 1e-12
+
+  hubbard_u1u1_y2_boundary_site_complex_time_matches_exact_time_dependent_window_solution:
+    use: hubbard_u1u1_y2_boundary_time_dependent_window_bond_complex
+    expect:
+      # Same two-site formula as the chain complex-time case, translated to site [1].
+      - expectation_real:
+          operator: "lat:Nup(1)[1]"
+          approx: 0.0008154855633248414
+          abs: 1e-12
+
+  hubbard_u1u1_y2_time_dependent_window_expands_and_preserves_particle_number:
+    use: hubbard_u1u1_y2_single_up_time_dependent_window
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowRight
+          approx: 4
+          abs: 1e-12
+
+  hubbard_u1u1_y2_time_dependent_window_keeps_expanding_over_multiple_steps:
+    use: hubbard_u1u1_y2_single_up_td_window_four_steps
+    expect:
+      - attr_float:
+          attribute: EvolutionWindowRight
+          approx: 5
+          abs: 1e-12

--- a/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
+++ b/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
@@ -16,10 +16,10 @@ fixtures:
   aklt_ground_uc1_rerun:
     from: lat
     steps:
-      - run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
+      - run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12 --seed 1
         outputs:
           state: psi
-      - run: mp-idmrg-s3e -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
+      - run: mp-idmrg-s3e -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12 --seed 1
     certify:
       - attr_text:
           attribute: Hamiltonian

--- a/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
+++ b/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
@@ -16,10 +16,10 @@ fixtures:
   aklt_ground_uc1_rerun:
     from: lat
     steps:
-      - run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32
+      - run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
         outputs:
           state: psi
-      - run: mp-idmrg-s3e -w psi -H lat:H_AKLT -m 8x32
+      - run: mp-idmrg-s3e -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
     certify:
       - attr_text:
           attribute: Hamiltonian

--- a/tests/suites/spinchain-aklt-spt-uc1.yaml
+++ b/tests/suites/spinchain-aklt-spt-uc1.yaml
@@ -15,7 +15,7 @@ fixtures:
 
   aklt_ground_uc1:
     from: lat
-    run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
+    run: mp-idmrg-s3e -e -b -u 1 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12 --seed 1
     outputs:
       state: psi
     certify:

--- a/tests/suites/spinchain-aklt-spt.yaml
+++ b/tests/suites/spinchain-aklt-spt.yaml
@@ -15,7 +15,7 @@ fixtures:
 
   aklt_ground:
     from: lat
-    run: mp-idmrg-s3e -e -b -u 2 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
+    run: mp-idmrg-s3e -e -b -u 2 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12 --seed 1
     outputs:
       state: psi
     certify:

--- a/tests/suites/spinchain-aklt-spt.yaml
+++ b/tests/suites/spinchain-aklt-spt.yaml
@@ -15,7 +15,7 @@ fixtures:
 
   aklt_ground:
     from: lat
-    run: mp-idmrg-s3e -e -b -u 2 -w psi -H lat:H_AKLT -m 8x32
+    run: mp-idmrg-s3e -e -b -u 2 -w psi -H lat:H_AKLT -m 8x32 --maxtol 1e-12
     outputs:
       state: psi
     certify:

--- a/tests/suites/spinchain-finite-algorithms.yaml
+++ b/tests/suites/spinchain-finite-algorithms.yaml
@@ -9,6 +9,11 @@ fixtures:
     outputs:
       lattice: lat
 
+  lat_plain:
+    run: spinchain -o lat_plain
+    outputs:
+      lattice: lat_plain
+
   neel4:
     from: lat
     run: mp-construct -l lat -o psi --finite 0.5:-0.5:0.5:-0.5
@@ -17,6 +22,35 @@ fixtures:
     certify:
       - norm:
           approx: 1.0
+          abs: 1e-12
+
+  up1_plain:
+    from: lat_plain
+    run: mp-construct -l lat_plain -o psi --finite 0.5
+    outputs:
+      state: psi
+    certify:
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+
+  upup2_plain:
+    from: lat_plain
+    run: mp-construct -l lat_plain -o psi --finite 0.5:0.5
+    outputs:
+      state: psi
+    certify:
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.5
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.5
           abs: 1e-12
 
   rand8:
@@ -64,6 +98,230 @@ fixtures:
           attribute: EvolutionHamiltonian
           equals: "lat:sum_unit(I(0))"
 
+  neel4_tdvp_time_dependent_identity_tau:
+    from: neel4
+    run: mp-tdvp -w psi -H "lat:(1+i*tau)*sum_unit(I(0))" -o out -t 0-0.1i -n 4 -s 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.4
+    certify:
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.0
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.4
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:(1+i*tau)*sum_unit(I(0))"
+
+  up1_tdvp_rotating_transverse_field:
+    from: up1_plain
+    run: mp-tdvp -w psi -H "lat_plain:sum_unit(cos(2*t)*Sx(0)+sin(2*t)*Sy(0))" -o out -t 0.01 -n 40 -s 40 --magnus 4 --magnus-quadrature 4
+    outputs:
+      state: out.t0.40
+    certify:
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: 0.07297403638686
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.17515481843217
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.46259656245308
+          abs: 1e-6
+
+  upup2_tebd_rotating_transverse_field:
+    from: upup2_plain
+    run: mp-tebd -w psi -H "lat_plain:sum_unit(sites=2,cos(2*t)*Sx(0)+sin(2*t)*Sy(0))" -o out -t 0.01 -n 40 -s 40 --magnus 4 --magnus-quadrature 4
+    outputs:
+      state: out.t0.40
+    certify:
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat_plain:sum_unit(sites=2,cos(2*t)*Sx(0)+sin(2*t)*Sy(0))"
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: 0.07297403638686
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.17515481843217
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.46259656245308
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  upup2_tebd_time_dependent_commuting_field_resume_real:
+    from: upup2_plain
+    steps:
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o half -t 0.4 -n 1 -s 1 --magnus 2
+        outputs:
+          state: half.t0.4
+        save_as:
+          state: half_state
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o resumed -t 0.4 -n 1 -s 1 --magnus 2
+        outputs:
+          state: resumed.t0.8
+    certify:
+      - attr_float:
+          state: half.t0.4
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.8
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))"
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  upup2_tebd_time_dependent_commuting_field_resume_complex:
+    from: upup2_plain
+    steps:
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o half -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2 --normalize
+        outputs:
+          state: half.t0.2.b0.1
+        save_as:
+          state: half_state
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o resumed -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2 --normalize
+        outputs:
+          state: resumed.t0.4.b0.2
+    certify:
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Time
+          approx: 0.2
+          abs: 1e-12
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.2
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))"
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: -0.13645254028157
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.21354813246347
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.43101960439413
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  upup2_tebd_time_dependent_commuting_field_resume_complex_unnormalized:
+    from: upup2_plain
+    steps:
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o half -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2
+        outputs:
+          state: half.t0.2.b0.1
+        save_as:
+          state: half_state
+      - run: mp-tebd -w {state} -H "lat_plain:sum_unit(sites=2,(1+t)*Sx(0))" -o resumed -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2
+        outputs:
+          state: resumed.t0.4.b0.2
+    certify:
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Time
+          approx: 0.2
+          abs: 1e-12
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.2
+          abs: 1e-12
+      - norm:
+          approx: 1.0158825380924
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: -0.14082138645699
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.22038537374793
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.44481970182219
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.51600866560055
+          abs: 1e-8
+
 tests:
   dmrg_3s_legacy_sweeps_path_converges_and_formats_real_energy_cleanly:
     use: rand8_dmrg_3s_s4
@@ -93,3 +351,112 @@ tests:
       - attr_text:
           attribute: EvolutionHamiltonian
           equals: "lat:sum_unit(I(0))"
+
+  tdvp_time_dependent_identity_accepts_magnus4_and_custom_timevar:
+    use: neel4_tdvp_time_dependent_identity_tau
+    expect:
+      - norm:
+          approx: 1.0
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.4
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:(1+i*tau)*sum_unit(I(0))"
+
+  tdvp_time_dependent_rotating_field_tracks_exact_single_spin_solution:
+    use: up1_tdvp_rotating_transverse_field
+    expect:
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: 0.07297403638686
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.17515481843217
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.46259656245308
+          abs: 1e-6
+
+  tebd_time_dependent_rotating_field_tracks_exact_single_spin_solution:
+    use: upup2_tebd_rotating_transverse_field
+    expect:
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: 0.07297403638686
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.17515481843217
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.46259656245308
+          abs: 1e-6
+      - expectation_real:
+          operator: "lat_plain:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  tebd_time_dependent_commuting_field_resumes_from_saved_time:
+    use: upup2_tebd_time_dependent_commuting_field_resume_real
+    expect:
+      - attr_float:
+          attribute: Time
+          approx: 0.8
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+
+  tebd_time_dependent_commuting_field_resumes_from_complex_time:
+    use: upup2_tebd_time_dependent_commuting_field_resume_complex
+    expect:
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.2
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: -0.13645254028157
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.21354813246347
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.43101960439413
+          abs: 1e-8
+
+  tebd_time_dependent_commuting_field_preserves_finite_complex_amplitude:
+    use: upup2_tebd_time_dependent_commuting_field_resume_complex_unnormalized
+    expect:
+      - norm:
+          approx: 1.0158825380924
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat_plain:Sx(0)"
+          approx: -0.14082138645699
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sy(0)"
+          approx: -0.22038537374793
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat_plain:Sz(0)"
+          approx: 0.44481970182219
+          abs: 1e-8

--- a/tests/suites/spinchain-ibc-dynamics.yaml
+++ b/tests/suites/spinchain-ibc-dynamics.yaml
@@ -100,6 +100,38 @@ fixtures:
           approx: 0.0
           abs: 1e-12
 
+  ibc_neel2_window_identity:
+    from: ibc_neel2
+    run: mp-ibc-apply --window "lat:I(0)" ibc ibc_window
+    outputs:
+      state: ibc_window
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 1"
+
+  ibc_neel2_tdvp_time_dependent_zero_window:
+    from: ibc_neel2_window_identity
+    run: mp-ibc-tdvp -w ibc_window -H "lat:sum_unit(I(0))" -W "lat:tau*0*I(0)" -o out -t 0-0.1i -n 1 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.1
+    certify:
+      - attr_float:
+          state: "{state}"
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
 tests:
   ibc_tdvp_identity_updates_beta_and_keeps_the_simple_overlap:
     use:
@@ -132,6 +164,23 @@ tests:
       - attr_float:
           state: "{psi2}"
           attribute: Time
+          approx: 0.1
+          abs: 1e-12
+
+  ibc_tdvp_accepts_time_dependent_window_operator:
+    use:
+      psi1: ibc_neel2_window_identity.state
+      psi2: ibc_neel2_tdvp_time_dependent_zero_window.state
+    expect:
+      - ibc_overlap_real:
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          approx: 0.0
+          abs: 1e-12
+      - attr_float:
+          state: "{psi2}"
+          attribute: Beta
           approx: 0.1
           abs: 1e-12
 

--- a/tests/suites/spinchain-ibc-dynamics.yaml
+++ b/tests/suites/spinchain-ibc-dynamics.yaml
@@ -71,6 +71,35 @@ fixtures:
           approx: 0.0
           abs: 1e-12
 
+  ibc_neel2_tdvp_ising_real:
+    from: ibc_neel2
+    run: mp-ibc-tdvp -w ibc -H "lat:-4*sum_unit(Sz(0)*Sz(1))" -o out -t 0.1 -n 1 -s 1 -m 4
+    outputs:
+      state: out.t0.1
+    certify:
+      - info_text:
+          state: "{state}"
+          contains: "Window size = 3"
+      - attr_float:
+          state: "{state}"
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      - attr_text:
+          state: "{state}"
+          attribute: EvolutionHamiltonian
+          equals: "lat:-4*sum_unit(Sz(0)*Sz(1))"
+      - ibc_overlap_real:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          psi1: "{parent.state}"
+          psi2: "{state}"
+          approx: 0.0
+          abs: 1e-12
+
 tests:
   ibc_tdvp_identity_updates_beta_and_keeps_the_simple_overlap:
     use:
@@ -86,6 +115,23 @@ tests:
       - attr_float:
           state: "{psi2}"
           attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+
+  ibc_tdvp_static_ising_real_time_preserves_simple_product_overlap:
+    use:
+      psi1: ibc_neel2.state
+      psi2: ibc_neel2_tdvp_ising_real.state
+    expect:
+      - ibc_overlap_real:
+          approx: 1.0
+          abs: 1e-12
+      - ibc_overlap_imag:
+          approx: 0.0
+          abs: 1e-12
+      - attr_float:
+          state: "{psi2}"
+          attribute: Time
           approx: 0.1
           abs: 1e-12
 

--- a/tests/suites/spinchain-tebd.yaml
+++ b/tests/suites/spinchain-tebd.yaml
@@ -275,6 +275,72 @@ fixtures:
           approx: 0.38481214455298
           abs: 1e-12
 
+  infinite_neel2_itdvp_time_dependent_imag_magnus4_tau:
+    from: infinite_neel2
+    run: mp-itdvp -w psi -H "lat:(1+i*tau)*sum_unit(I(0))" -o out -t 0-0.1i -n 4 -s 1 -m 4 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.4
+      state_b0p1: out.b0.1
+      state_b0p2: out.b0.2
+      state_b0p3: out.b0.3
+      state_b0p4: out.b0.4
+    certify:
+      - attr_float:
+          attribute: Beta
+          approx: 0.4
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:(1+i*tau)*sum_unit(I(0))"
+      - ioverlap_real:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.38481214455298
+          abs: 1e-12
+      - ioverlap_imag:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.38481214455298
+          abs: 1e-12
+
+  infinite_neel2_itebd_time_dependent_imag_magnus4_tau:
+    from: infinite_neel2
+    run: mp-itebd -w psi -H "lat:(1+i*tau)*sum_unit(I(0))" -o out -t 0-0.1i -n 4 -s 1 --magnus 4 --magnus-quadrature 3 --timevar tau
+    outputs:
+      state: out.b0.4
+      state_b0p1: out.b0.1
+      state_b0p2: out.b0.2
+      state_b0p3: out.b0.3
+      state_b0p4: out.b0.4
+    certify:
+      - attr_float:
+          attribute: Beta
+          approx: 0.4
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:(1+i*tau)*sum_unit(I(0))"
+      - ioverlap_real:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.38289288597511
+          abs: 1e-12
+      - ioverlap_imag:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.0
+          abs: 1e-12
+      - ioverlap_mag:
+          state: "{state_b0p4}"
+          psi2: "{parent.state}"
+          approx: 0.38289288597511
+          abs: 1e-12
+
 
   lat_plain:
     run: spinchain -o lat
@@ -308,6 +374,160 @@ fixtures:
           operator: "lat:Sz(0)"
           approx: 0.49750208263901
           abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itebd_rotating_transverse_field:
+    from: infinite_upup2
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=2,cos(2*t)*Sx(0)+sin(2*t)*Sy(0))" -o out -t 0.01 -n 10 -s 10 --magnus 4 --magnus-quadrature 4
+    outputs:
+      state: out.t0.10
+    certify:
+      - attr_float:
+          attribute: Time
+          approx: 0.1
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:sum_unit(sites=2,cos(2*t)*Sx(0)+sin(2*t)*Sy(0))"
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: 0.0049709455177231
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.049585202107799
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.49751039932105
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itebd_time_dependent_commuting_field_continuation:
+    from: infinite_upup2
+    run: mp-itebd -w psi -H "lat:sum_unit(sites=2,(1+t)*Sx(0))" -o out -t 0.4 -n 2 -s 2 --magnus 2
+    outputs:
+      state: out.t0.8
+    certify:
+      - attr_float:
+          attribute: Time
+          approx: 0.8
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:sum_unit(sites=2,(1+t)*Sx(0))"
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itebd_time_dependent_commuting_field_resume_real:
+    from: infinite_upup2
+    steps:
+      - run: mp-itebd -w {state} -H "lat:sum_unit(sites=2,(1+t)*Sx(0))" -o half -t 0.4 -n 1 -s 1 --magnus 2
+        outputs:
+          state: half.t0.4
+        save_as:
+          state: half_state
+      - run: mp-itebd -w {state} -H "lat:sum_unit(sites=2,(1+t)*Sx(0))" -o resumed -t 0.4 -n 1 -s 1 --magnus 2
+        outputs:
+          state: resumed.t0.8
+    certify:
+      - attr_float:
+          state: half.t0.4
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.8
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:sum_unit(sites=2,(1+t)*Sx(0))"
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  infinite_upup2_itebd_time_dependent_commuting_field_resume_complex:
+    from: infinite_upup2
+    steps:
+      - run: mp-itebd -w {state} -H "lat:sum_unit(sites=2,(1+t)*Sx(0))" -o half -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2
+        outputs:
+          state: half.t0.2.b0.1
+        save_as:
+          state: half_state
+      - run: mp-itebd -w {state} -H "lat:sum_unit(sites=2,(1+t)*Sx(0))" -o resumed -t 0.2 -b 0.1 -n 1 -s 1 --magnus 2
+        outputs:
+          state: resumed.t0.4.b0.2
+    certify:
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Time
+          approx: 0.2
+          abs: 1e-12
+      - attr_float:
+          state: half.t0.2.b0.1
+          attribute: Beta
+          approx: 0.1
+          abs: 1e-12
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.2
+          abs: 1e-12
+      - attr_text:
+          attribute: EvolutionHamiltonian
+          equals: "lat:sum_unit(sites=2,(1+t)*Sx(0))"
+      - info_log_amplitude:
+          approx: 0.01934912339218324
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: -0.13645254028157
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.21354813246347
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.43101960439413
+          abs: 1e-8
       - expectation_real:
           operator: "lat:Sz(1)"
           approx: 0.5
@@ -604,6 +824,89 @@ tests:
           approx: 1.0
           abs: 1e-12
 
+  itebd_time_dependent_rotating_field_tracks_exact_single_spin_solution:
+    use: infinite_upup2_itebd_rotating_transverse_field
+    expect:
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: 0.0049709455177231
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.049585202107799
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.49751039932105
+          abs: 1e-4
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  itebd_time_dependent_continuation_slice_uses_boundary_interval:
+    use: infinite_upup2_itebd_time_dependent_commuting_field_continuation
+    expect:
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: 0.0
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(1)"
+          approx: 0.5
+          abs: 1e-12
+
+  itebd_time_dependent_resume_uses_saved_time_attribute:
+    use: infinite_upup2_itebd_time_dependent_commuting_field_resume_real
+    expect:
+      - attr_float:
+          attribute: Time
+          approx: 0.8
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.45005022108825
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.21784122313836
+          abs: 1e-8
+
+  itebd_time_dependent_resume_uses_saved_complex_time_attribute:
+    use: infinite_upup2_itebd_time_dependent_commuting_field_resume_complex
+    expect:
+      - attr_float:
+          attribute: Time
+          approx: 0.4
+          abs: 1e-12
+      - attr_float:
+          attribute: Beta
+          approx: 0.2
+          abs: 1e-12
+      - info_log_amplitude:
+          approx: 0.01934912339218324
+          abs: 1e-12
+      - expectation_real:
+          operator: "lat:Sx(0)"
+          approx: -0.13645254028157
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sy(0)"
+          approx: -0.21354813246347
+          abs: 1e-8
+      - expectation_real:
+          operator: "lat:Sz(0)"
+          approx: 0.43101960439413
+          abs: 1e-8
+
 
   itebd_site_dependent_two_site_drive_on_second_site_matches_itdvp:
     use:
@@ -813,6 +1116,64 @@ tests:
           psi1: "{psi0}"
           psi2: "{beta_0p4}"
           approx: 0.38481214455298
+          abs: 1e-12
+
+  itdvp_time_dependent_imaginary_time_magnus4_respects_custom_timevar:
+    use:
+      psi0: infinite_neel2.state
+      beta_0p1: infinite_neel2_itdvp_time_dependent_imag_magnus4_tau.state_b0p1
+      beta_0p2: infinite_neel2_itdvp_time_dependent_imag_magnus4_tau.state_b0p2
+      beta_0p3: infinite_neel2_itdvp_time_dependent_imag_magnus4_tau.state_b0p3
+      beta_0p4: infinite_neel2_itdvp_time_dependent_imag_magnus4_tau.state_b0p4
+    expect:
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p1}"
+          approx: 0.81464731641141
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p2}"
+          approx: 0.64726466707803
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p3}"
+          approx: 0.50409022957483
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p4}"
+          approx: 0.38481214455298
+          abs: 1e-12
+
+  itebd_time_dependent_imaginary_time_magnus4_respects_custom_timevar:
+    use:
+      psi0: infinite_neel2.state
+      beta_0p1: infinite_neel2_itebd_time_dependent_imag_magnus4_tau.state_b0p1
+      beta_0p2: infinite_neel2_itebd_time_dependent_imag_magnus4_tau.state_b0p2
+      beta_0p3: infinite_neel2_itebd_time_dependent_imag_magnus4_tau.state_b0p3
+      beta_0p4: infinite_neel2_itebd_time_dependent_imag_magnus4_tau.state_b0p4
+    expect:
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p1}"
+          approx: 0.81058424597019
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p2}"
+          approx: 0.64403642108314
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p3}"
+          approx: 0.50157606906606
+          abs: 1e-12
+      - ioverlap_real:
+          psi1: "{psi0}"
+          psi2: "{beta_0p4}"
+          approx: 0.38289288597511
           abs: 1e-12
 
   imoments_cross_json_reuses_itebd_output:


### PR DESCRIPTION
Summary:
- Add a shared time-dependent MPO/Magnus helper with configurable Gauss-Legendre quadrature.
- Move TEBD bond-gate construction into shared finite and periodic helpers, and use it from mp-itebd and mp-tebd.
- Add finite mp-tebd support for time-dependent Hamiltonians, including correct continuation-slice intervals.
- Add regression tests for site-dependent iTEBD, finite TEBD time-dependent evolution, real/complex resume, and finite/infinite amplitude handling.

Notes:
- The iMPS amplitude check currently uses an mp-info probe because mp-norm does not yet support iMPS. That can be replaced once mp-norm is patched.
- Resolves #93.

Verification:
- cmake --build build-codex/cmake --parallel --target mp-tebd mp-itebd
- scripts/mptk-test --bin-dir build-codex/cmake --config Release --work-root build-codex/test-work/finite-tebd-suite2 spinchain-finite-algorithms spinchain-tebd
- make -C build-codex/autoconf -j20 mp-tebd mp-itebd
- git diff --cached --check