### PR TITLE
[codex] Reduce CMake link size and LTO fanout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,11 @@ jobs:
     - name: Install dependencies
       run: |
        sudo apt-get -y update
-       sudo apt-get -y install \
-         g++ \
+       sudo apt-get -y install --no-install-recommends \
          libarpack2-dev \
          libboost-program-options-dev \
          libgmp-dev \
          libopenblas-dev \
-         ninja-build \
          python3-yaml
     - name: Configure
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(MPToolkit LANGUAGES C CXX)
 if(CMAKE_CONFIGURATION_TYPES)
   message(FATAL_ERROR
     "MPToolkit's CMake bootstrap currently supports only single-config generators. "
-    "Use Ninja or Unix Makefiles with -DCMAKE_BUILD_TYPE=Release or Debug.")
+    "Use Ninja (recommended) or Unix Makefiles with -DCMAKE_BUILD_TYPE=Release or Debug.")
 endif()
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -29,12 +29,67 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(MPTK_WITH_OPENMP "Enable OpenMP support" OFF)
 option(MPTK_WITH_PSTREAM "Enable persistent stream support" ON)
 option(MPTK_BUILD_CONTRIB_MODELS "Build models/contrib generators" OFF)
+option(MPTK_ENABLE_IPO "Enable IPO/LTO for Release and MinSizeRel builds when supported" ON)
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  set(MPTK_DEFAULT_IPO_JOBS auto)
+else()
+  set(MPTK_DEFAULT_IPO_JOBS 1)
+endif()
+set(MPTK_IPO_JOBS "${MPTK_DEFAULT_IPO_JOBS}" CACHE STRING "GNU IPO/LTO worker count: positive integer, jobserver, or auto")
+set_property(CACHE MPTK_IPO_JOBS PROPERTY STRINGS 1 2 4 8 16 jobserver auto)
+set(MPTK_LINK_JOBS "1" CACHE STRING "Ninja-only maximum concurrent link jobs; empty uses the generator default")
+set_property(CACHE MPTK_LINK_JOBS PROPERTY STRINGS "" 1 2 4 8 16)
 set(MPTK_BLAS_VENDOR "auto" CACHE STRING "BLAS vendor for version reporting: auto, generic, OpenBLAS, or MKL")
 set_property(CACHE MPTK_BLAS_VENDOR PROPERTY STRINGS auto generic OpenBLAS MKL)
 set(MPTK_BLAS_VENDOR_VALUES auto generic OpenBLAS MKL)
 if(NOT MPTK_BLAS_VENDOR IN_LIST MPTK_BLAS_VENDOR_VALUES)
   message(FATAL_ERROR "MPTK_BLAS_VENDOR must be one of: auto, generic, OpenBLAS, MKL")
 endif()
+if(NOT MPTK_LINK_JOBS STREQUAL "")
+  if(NOT MPTK_LINK_JOBS MATCHES "^[1-9][0-9]*$")
+    message(FATAL_ERROR "MPTK_LINK_JOBS must be empty or a positive integer")
+  endif()
+  if(CMAKE_GENERATOR MATCHES "Ninja")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS "mptk_link_pool=${MPTK_LINK_JOBS}")
+    if(NOT DEFINED CMAKE_JOB_POOL_LINK OR CMAKE_JOB_POOL_LINK STREQUAL "")
+      set(CMAKE_JOB_POOL_LINK mptk_link_pool)
+    endif()
+  endif()
+endif()
+
+function(mptk_configure_gnu_ipo_jobs lang)
+  if(NOT CMAKE_${lang}_COMPILER_ID STREQUAL "GNU")
+    return()
+  endif()
+  if(NOT MPTK_IPO_JOBS MATCHES "^(auto|jobserver|[1-9][0-9]*)$")
+    message(FATAL_ERROR "MPTK_IPO_JOBS must be a positive integer, jobserver, or auto")
+  endif()
+  if(DEFINED CMAKE_${lang}_COMPILE_OPTIONS_IPO)
+    set(_ipo_options ${CMAKE_${lang}_COMPILE_OPTIONS_IPO})
+    list(TRANSFORM _ipo_options REPLACE "^-flto(=.*)?$" "-flto=${MPTK_IPO_JOBS}")
+    set(CMAKE_${lang}_COMPILE_OPTIONS_IPO ${_ipo_options} PARENT_SCOPE)
+  endif()
+endfunction()
+
+if(MPTK_ENABLE_IPO)
+  mptk_configure_gnu_ipo_jobs(C)
+  mptk_configure_gnu_ipo_jobs(CXX)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT MPTK_IPO_SUPPORTED OUTPUT MPTK_IPO_ERROR LANGUAGES C CXX)
+  if(MPTK_IPO_SUPPORTED)
+    if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION AND
+       NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE)
+      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+    endif()
+    if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION AND
+       NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL)
+      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
+    endif()
+  else()
+    message(STATUS "IPO/LTO not enabled: ${MPTK_IPO_ERROR}")
+  endif()
+endif()
+
 set(MPTK_FORTRAN_COMPLEX_RETURN "auto" CACHE STRING "Fortran complex return convention: auto, register, or first_arg")
 set_property(CACHE MPTK_FORTRAN_COMPLEX_RETURN PROPERTY STRINGS auto register first_arg)
 set(MPTK_FORTRAN_COMPLEX_RETURN_VALUES auto register first_arg)
@@ -402,10 +457,25 @@ if(MPTK_WITH_OPENMP)
   target_link_libraries(mptoolkit_config INTERFACE OpenMP::OpenMP_CXX)
 endif()
 
+set(MPTK_SYMMETRY_REGISTRAR_SOURCES
+  quantumnumbers/null-quantumnumber.cpp
+  quantumnumbers/su2.cpp
+  quantumnumbers/u1.cpp
+  quantumnumbers/z2.cpp
+  quantumnumbers/zn.cpp
+)
+list(REMOVE_ITEM MPTK_CORE_SOURCES ${MPTK_SYMMETRY_REGISTRAR_SOURCES})
+
 add_library(mptoolkit_core_objects OBJECT ${MPTK_CORE_SOURCES})
 target_link_libraries(mptoolkit_core_objects PUBLIC mptoolkit_config)
 
-add_library(mptoolkit_core STATIC $<TARGET_OBJECTS:mptoolkit_core_objects>)
+add_library(mptoolkit_symmetry_registrar_objects OBJECT ${MPTK_SYMMETRY_REGISTRAR_SOURCES})
+target_link_libraries(mptoolkit_symmetry_registrar_objects PUBLIC mptoolkit_config)
+
+add_library(mptoolkit_core STATIC
+  $<TARGET_OBJECTS:mptoolkit_core_objects>
+  $<TARGET_OBJECTS:mptoolkit_symmetry_registrar_objects>
+)
 target_link_libraries(mptoolkit_core PUBLIC mptoolkit_config)
 
 add_library(mptoolkit_algorithms_objects OBJECT ${MPTK_ALGORITHM_SOURCES})
@@ -429,9 +499,11 @@ endfunction()
 
 function(mptk_add_executable target source subdir)
   add_executable("${target}" "${source}" ${ARGN})
-  # Core contains static symmetry registrars, so link the object library
-  # directly; a static archive can drop otherwise unreferenced registrars.
-  target_link_libraries("${target}" PRIVATE mptoolkit_core_objects mptoolkit_algorithms)
+  # Symmetry registration relies on static initializers in these translation
+  # units. Link only those objects directly; the rest of core remains a normal
+  # archive so unused object files can be discarded by the linker.
+  target_sources("${target}" PRIVATE $<TARGET_OBJECTS:mptoolkit_symmetry_registrar_objects>)
+  target_link_libraries("${target}" PRIVATE mptoolkit_algorithms)
   mptk_set_runtime_output("${target}" "${subdir}")
 endfunction()
 
@@ -624,6 +696,8 @@ function(mptk_print_configuration_summary)
     BLA_VENDOR
     CMAKE_CXX_FLAGS
     CMAKE_CXX_FLAGS_${_config_upper}
+    CMAKE_INTERPROCEDURAL_OPTIMIZATION_${_config_upper}
+    CMAKE_JOB_POOL_LINK
   )
 
   message(STATUS "===== Common CMake Options =====")

--- a/README.md
+++ b/README.md
@@ -11,24 +11,31 @@ Documentation for the toolkit is available from https://mptoolkit.qusim.net/
 MPToolkit includes an initial CMake build. It is intended to live alongside the
 existing Autoconf build while the CMake configuration is being completed.
 
-Configure an out-of-tree build with a user-writable install prefix:
+Configure an out-of-tree build with a user-writable install prefix. Ninja is
+recommended when available:
 
 ```sh
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX="$HOME/mptk"
+cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX="$HOME/mptk"
 ```
 
 The CMake build defaults to `Release`. For a developer debug build, configure a
 separate build tree:
 
 ```sh
-cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug
+cmake -S . -B build-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
 ```
+
+Release builds enable IPO/LTO when the compiler supports it. Ninja is
+recommended for parallel builds because the CMake configuration limits
+concurrent LTO links without disabling parallelism inside the active link.
 
 The default build target builds the standard tools and model generators:
 
 ```sh
-cmake --build build --parallel
+cmake --build build --parallel 4
 ```
+
+Adjust the `--parallel` value for your machine.
 
 The CMake bootstrap currently supports LP64 BLAS/LAPACK builds. It validates
 the selected numerical backend against ARPACK where possible and aborts for
@@ -61,7 +68,7 @@ Contrib model generators are not built by default. To enable them, configure
 with:
 
 ```sh
-cmake -S . -B build-contrib \
+cmake -S . -B build-contrib -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$HOME/mptk" \
   -DMPTK_BUILD_CONTRIB_MODELS=ON
 ```
@@ -70,8 +77,8 @@ Then build individual contrib models by target name, or build all standard and
 contrib models:
 
 ```sh
-cmake --build build-contrib --target bosehubbard-flux-2leg-u1 --parallel
-cmake --build build-contrib --target all-models --parallel
+cmake --build build-contrib --target bosehubbard-flux-2leg-u1 --parallel 4
+cmake --build build-contrib --target all-models --parallel 4
 ```
 
 The aggregate contrib-only target is `contrib-models`, and contrib model


### PR DESCRIPTION
## Summary

This keeps the CMake bootstrap's Release binaries closer to the existing Autoconf output size while avoiding runaway GNU LTO parallelism.

Changes:
- enable IPO/LTO for Release and MinSizeRel when CMake reports support
- use `-flto=auto` by default with Ninja so the active LTO link can parallelize internally
- add a Ninja link job pool default so IPO links do not pile up under high build parallelism
- keep non-Ninja generators conservative by default, while still allowing `MPTK_IPO_JOBS` to be overridden
- link only the quantum-number symmetry registrar object files directly into executables, leaving the rest of core as a normal static archive so unused objects can be discarded
- update the README CMake examples to recommend Ninja and keep user-facing guidance simpler
- trim the GitHub Actions apt install to packages not already provided by the Ubuntu 24.04 runner, using `--no-install-recommends`

## Validation

- `cmake -S . -B build-codex/cmake-link-ninja-auto -G Ninja -DCMAKE_BUILD_TYPE=Release`
- confirmed generated Ninja rules use `-flto=auto`
- confirmed generated Ninja link pool `mptk_link_pool` has `depth = 1`
- `cmake --build build-codex/cmake-link-ninja-auto --parallel 4 --target mp-info clock clock-zn mp-lattice-info testexponential`
- `scripts/mptk-test --bin-dir build-codex/cmake-link-ninja-auto --config Release --work-root build-codex/cmake-link-ninja-auto/test-work clock-smoke`
- `ctest --test-dir build-codex/cmake-link-ninja-auto --output-on-failure`
- `git diff --check`

Root source directory build-artifact scan was clean.