### PR TITLE
[codex] Add MP_BENCHFILE filename templates

### DIFF
--- a/common/environment.h
+++ b/common/environment.h
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <string>
 #include <stdlib.h> // for getenv
+#include <sys/stat.h>
 
 inline
 std::string quote_shell(std::string s)
@@ -98,10 +99,43 @@ inline
 std::string format_date_time(std::string const& Format)
 {
    std::time_t Time = std::time(nullptr);
-   std::tm LocalTime = *std::localtime(&Time);
-   char Buffer[100] = {};
-   std::strftime(Buffer, sizeof(Buffer), Format.c_str(), &LocalTime);
-   return std::string(Buffer);
+   std::tm LocalTime;
+#if defined(_WIN32) || defined(_MSC_VER)
+   if (localtime_s(&LocalTime, &Time) != 0)
+      return std::string();
+#else
+   if (localtime_r(&Time, &LocalTime) == nullptr)
+      return std::string();
+#endif
+
+   std::ostringstream Out;
+   Out << std::put_time(&LocalTime, Format.c_str());
+   return Out ? Out.str() : std::string();
+}
+
+inline
+bool bench_filename_exists(std::string const& FileName)
+{
+   struct stat Buffer;
+   return stat(FileName.c_str(), &Buffer) == 0;
+}
+
+inline
+bool parse_bench_filename_width(std::string const& WidthStr, int& Width)
+{
+   int const MaxWidth = 100;
+   Width = 0;
+   for (char c : WidthStr)
+   {
+      if (c < '0' || c > '9')
+         return false;
+      int const Digit = c - '0';
+      // Avoid exceptions and pathological filename padding from bad environment values.
+      if (Width > (MaxWidth - Digit) / 10)
+         return false;
+      Width = Width * 10 + Digit;
+   }
+   return true;
 }
 
 // Find an unused filename of the form BaseName + N + Extension, where N is
@@ -119,7 +153,7 @@ std::string find_next_unused_filename(std::string const& BaseName, std::string c
       Out.clear();
       Out << std::setw(Width) << std::setfill('0') << Number++;
       FileName = BaseName + Out.str() + Extension;
-   } while (std::ifstream(FileName));
+   } while (bench_filename_exists(FileName));
    return FileName;
 }
 
@@ -145,10 +179,11 @@ std::string replace_filename_format_specifiers(std::string FileName)
    for (auto const& Format : FormatMap)
    {
       std::size_t Pos = 0;
+      std::size_t const TokenLength = std::char_traits<char>::length(Format.Token);
       while ((Pos = FileName.find(Format.Token, Pos)) != std::string::npos)
       {
          std::string Replacement = format_date_time(Format.Format);
-         FileName.replace(Pos, 2, Replacement);
+         FileName.replace(Pos, TokenLength, Replacement);
          Pos += Replacement.length();
       }
    }
@@ -162,7 +197,9 @@ std::string replace_filename_format_specifiers(std::string FileName)
       if (End < FileName.size() && FileName[End] == 'n')
       {
          std::string WidthStr = FileName.substr(Pos + 1, End - Pos - 1);
-         int Width = WidthStr.empty() ? 0 : std::stoi(WidthStr);
+         int Width = 0;
+         if (!parse_bench_filename_width(WidthStr, Width))
+            return std::string();
          FileName = find_next_unused_filename(FileName.substr(0, Pos), FileName.substr(End + 1),
                                               Width);
          break;
@@ -183,7 +220,7 @@ std::ofstream open_bench_file(std::string FileName)
 
    bool Append = false;
    bool BlankLine = false;
-   if (FileName[0] == '+')
+   if (!FileName.empty() && FileName[0] == '+')
    {
       Append = true;
       FileName.erase(0, 1);

--- a/common/environment.h
+++ b/common/environment.h
@@ -21,6 +21,10 @@
 #define ENVIRONMENT_H_KHCJKSHDUY478Y5478YOPEW
 
 #include "common/stringutil.h"
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
 #include <string>
 #include <stdlib.h> // for getenv
 
@@ -87,6 +91,118 @@ getenv_or_default(std::string const& str, char const* Default)
 {
    char const* Str = getenv(str.c_str());
    return Str ? Str : Default;
+}
+
+// Format the current local date/time using strftime format specifiers.
+inline
+std::string format_date_time(std::string const& Format)
+{
+   std::time_t Time = std::time(nullptr);
+   std::tm LocalTime = *std::localtime(&Time);
+   char Buffer[100] = {};
+   std::strftime(Buffer, sizeof(Buffer), Format.c_str(), &LocalTime);
+   return std::string(Buffer);
+}
+
+// Find an unused filename of the form BaseName + N + Extension, where N is
+// zero-padded to at least Width digits.
+inline
+std::string find_next_unused_filename(std::string const& BaseName, std::string const& Extension,
+                                      int Width = 0)
+{
+   int Number = 1;
+   std::string FileName;
+   std::ostringstream Out;
+   do
+   {
+      Out.str("");
+      Out.clear();
+      Out << std::setw(Width) << std::setfill('0') << Number++;
+      FileName = BaseName + Out.str() + Extension;
+   } while (std::ifstream(FileName));
+   return FileName;
+}
+
+// Replace filename format specifiers used by MP_BENCHFILE.
+inline
+std::string replace_filename_format_specifiers(std::string FileName)
+{
+   struct FormatSpecifier
+   {
+      char const* Token;
+      char const* Format;
+   };
+
+   FormatSpecifier const FormatMap[] = {
+      {"%D", "%Y-%m-%d-%H:%M:%S"},
+      {"%T", "%H:%M:%S"},
+      {"%F", "%Y-%m-%d"},
+      {"%C", "%Y%m%d_%H%M%S"},
+      {"%z", "%z"},
+      {"%Z", "%Z"}
+   };
+
+   for (auto const& Format : FormatMap)
+   {
+      std::size_t Pos = 0;
+      while ((Pos = FileName.find(Format.Token, Pos)) != std::string::npos)
+      {
+         std::string Replacement = format_date_time(Format.Format);
+         FileName.replace(Pos, 2, Replacement);
+         Pos += Replacement.length();
+      }
+   }
+
+   std::size_t Pos = FileName.find('%');
+   while (Pos != std::string::npos)
+   {
+      std::size_t End = Pos + 1;
+      while (End < FileName.size() && FileName[End] >= '0' && FileName[End] <= '9')
+         ++End;
+      if (End < FileName.size() && FileName[End] == 'n')
+      {
+         std::string WidthStr = FileName.substr(Pos + 1, End - Pos - 1);
+         int Width = WidthStr.empty() ? 0 : std::stoi(WidthStr);
+         FileName = find_next_unused_filename(FileName.substr(0, Pos), FileName.substr(End + 1),
+                                              Width);
+         break;
+      }
+      Pos = FileName.find('%', Pos + 1);
+   }
+
+   return FileName;
+}
+
+// Open an MP_BENCHFILE-style output stream. A leading '+' appends, and a
+// leading '++' appends after writing a blank separator line.
+inline
+std::ofstream open_bench_file(std::string FileName)
+{
+   if (FileName.empty())
+      return std::ofstream();
+
+   bool Append = false;
+   bool BlankLine = false;
+   if (FileName[0] == '+')
+   {
+      Append = true;
+      FileName.erase(0, 1);
+      if (!FileName.empty() && FileName[0] == '+')
+      {
+         BlankLine = true;
+         FileName.erase(0, 1);
+      }
+   }
+
+   FileName = replace_filename_format_specifiers(FileName);
+   if (FileName.empty())
+      return std::ofstream();
+
+   std::ofstream Out(FileName, std::ios_base::out |
+                              (Append ? std::ios_base::app : std::ios_base::trunc));
+   if (BlankLine && Out.good())
+      Out << '\n';
+   return Out;
 }
 
 #endif

--- a/mp/mp-dmrg-2site.cpp
+++ b/mp/mp-dmrg-2site.cpp
@@ -38,8 +38,8 @@
 
 namespace prog_opt = boost::program_options;
 
-bool Bench = (getenv_or_default("MP_BENCHFILE", "") != std::string());
-std::ofstream BenchFile(getenv_or_default("MP_BENCHFILE", ""), std::ios_base::out | std::ios_base::trunc);
+std::ofstream PerStepFile(open_bench_file(getenv_or_default("MP_BENCHFILE", "")));
+bool PerStep = PerStepFile.good();
 
 bool Flush = false;  // set to true to flush standard output every step
 
@@ -164,11 +164,13 @@ void SweepRight(FiniteDMRG2Site& dmrg, StatesInfo const& States)
          << '\n';
       if (Flush)
          std::cout << std::flush;
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -193,11 +195,13 @@ void SweepLeft(FiniteDMRG2Site& dmrg, StatesInfo const& States)
       if (Flush)
          std::cout << std::flush;
       SweepTruncation += Info.TruncationError();
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()+1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()+1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -289,15 +293,15 @@ int main(int argc, char** argv)
 
       std::cout.precision(getenv_or_default("MP_PRECISION", 14));
       std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
-      BenchFile.precision(getenv_or_default("MP_PRECISION", 14));
+      PerStepFile.precision(getenv_or_default("MP_PRECISION", 14));
 
       if (!Quiet)
          print_preamble(std::cout, argc, argv);
 
-      if (Bench)
+      if (PerStep)
       {
-         print_preamble(BenchFile, argc, argv);
-         BenchFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
+         print_preamble(PerStepFile, argc, argv);
+         PerStepFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
       }
 
       std::cout << "Starting DMRG...\n";

--- a/mp/mp-dmrg-3s.cpp
+++ b/mp/mp-dmrg-3s.cpp
@@ -38,8 +38,8 @@
 
 namespace prog_opt = boost::program_options;
 
-bool Bench = (getenv_or_default("MP_BENCHFILE", "") != std::string());
-std::ofstream BenchFile(getenv_or_default("MP_BENCHFILE", ""), std::ios_base::out | std::ios_base::trunc);
+std::ofstream PerStepFile(open_bench_file(getenv_or_default("MP_BENCHFILE", "")));
+bool PerStep = PerStepFile.good();
 
 bool Flush = false;  // set to true to flush standard output every step
 
@@ -114,12 +114,14 @@ void SweepRight(FiniteDMRG3S& dmrg, StatesInfo const& SInfo, double MixFactor)
          << '\n';
       if (Flush)
          std::cout << std::flush;
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
 
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -143,12 +145,14 @@ void SweepLeft(FiniteDMRG3S& dmrg, StatesInfo const& SInfo, double MixFactor)
          << '\n';
       if (Flush)
          std::cout << std::flush;
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()+1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
 
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -242,15 +246,15 @@ int main(int argc, char** argv)
 
       std::cout.precision(getenv_or_default("MP_PRECISION", 14));
       std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
-      BenchFile.precision(getenv_or_default("MP_PRECISION", 14));
+      PerStepFile.precision(getenv_or_default("MP_PRECISION", 14));
 
       if (!Quiet)
          print_preamble(std::cout, argc, argv);
 
-      if (Bench)
+      if (PerStep)
       {
-         print_preamble(BenchFile, argc, argv);
-         BenchFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
+         print_preamble(PerStepFile, argc, argv);
+         PerStepFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
       }
 
       std::cout << "Starting DMRG...\n";

--- a/mp/mp-dmrg.cpp
+++ b/mp/mp-dmrg.cpp
@@ -38,8 +38,8 @@
 
 namespace prog_opt = boost::program_options;
 
-bool Bench = (getenv_or_default("MP_BENCHFILE", "") != std::string());
-std::ofstream BenchFile(getenv_or_default("MP_BENCHFILE", ""), std::ios_base::out | std::ios_base::trunc);
+std::ofstream PerStepFile(open_bench_file(getenv_or_default("MP_BENCHFILE", "")));
+bool PerStep = PerStepFile.good();
 
 bool Flush = false;  // set to true to flush standard output every step
 
@@ -101,12 +101,14 @@ void SweepRight(FiniteDMRG& dmrg, StatesInfo const& States, ExpansionInfo const&
          << '\n';
       if (Flush)
          std::cout << std::flush;
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()-1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
 
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -141,12 +143,14 @@ void SweepLeft(FiniteDMRG& dmrg, StatesInfo const& States, ExpansionInfo const& 
          << '\n';
       if (Flush)
          std::cout << std::flush;
-      if (Bench)
-         BenchFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()+1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
+      if (PerStep)
+         PerStepFile << ProcControl::GetElapsedTime() << ' ' << dmrg.TotalNumSweeps << ' ' << (dmrg.Site()+1) << ' ' << Info.KeptStates() << ' ' << formatting::format_complex(dmrg.Solver().LastEnergy()) << ' ' << Info.TruncationError() << ' ' << dmrg.Solver().LastFidelityLoss() << ' ' << dmrg.Solver().LastIter() << ' ' << dmrg.Solver().LastTol() << '\n';
       dmrg.EndIteration();
    }
 
    dmrg.EndSweep();
+   if (PerStep)
+      PerStepFile.flush();
    std::cout << "Cumulative truncation error for sweep: " << dmrg.SweepTotalTruncation << '\n';
    std::cout << "Sweep fidelity loss: " << (1.0 - dmrg.LastSweepFidelity) << '\n';
 }
@@ -263,15 +267,15 @@ int main(int argc, char** argv)
 
       std::cout.precision(getenv_or_default("MP_PRECISION", 14));
       std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
-      BenchFile.precision(getenv_or_default("MP_PRECISION", 14));
+      PerStepFile.precision(getenv_or_default("MP_PRECISION", 14));
 
       if (!Quiet)
          print_preamble(std::cout, argc, argv);
 
-      if (Bench)
+      if (PerStep)
       {
-         print_preamble(BenchFile, argc, argv);
-         BenchFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
+         print_preamble(PerStepFile, argc, argv);
+         PerStepFile << "#Time #SweepNum #Site #States #Energy #Trunc #Fidelity #Iter #Tol\n";
       }
 
       std::cout << "Starting DMRG...\n";

--- a/mp/mp-idmrg-s3e.cpp
+++ b/mp/mp-idmrg-s3e.cpp
@@ -67,6 +67,7 @@
 #include "common/proccontrol.h"
 #include "common/formatting.h"
 #include "common/prog_options.h"
+#include <fstream>
 #include <iostream>
 #include "common/environment.h"
 #include "common/unique.h"
@@ -101,6 +102,9 @@ double const iTol = 1E-7;
 MatrixOperator GlobalU;
 
 bool EarlyTermination = false;  // we set this to true if we get a checkpoint
+
+std::ofstream PerStepFile(open_bench_file(getenv_or_default("MP_BENCHFILE", "")));
+bool PerStep = PerStepFile.good();
 
 
 LinearAlgebra::DiagonalMatrix<double>
@@ -908,9 +912,10 @@ iDMRG::Solve()
 void
 iDMRG::ShowInfo(char c)
 {
+   std::complex<double> Energy = Solver_.LastEnergy();
    std::cout << c
              << " Sweep=" << SweepNumber
-             << " Energy=" << formatting::format_complex(Solver_.LastEnergy())
+             << " Energy=" << formatting::format_complex(Energy)
              << " States=" << Info.KeptStates()
              << " TruncError=" << Info.TruncationError()
              << " Entropy=" << Info.KeptEntropy()
@@ -919,6 +924,15 @@ iDMRG::ShowInfo(char c)
              << " Iter=" << Solver_.LastIter()
              << " Tol=" << Solver_.LastTol()
              << '\n';
+   if (PerStep)
+   {
+      PerStepFile << ProcControl::GetElapsedTime() << ' ' << c << ' ' << SweepNumber << ' '
+                  << Info.KeptStates() << ' ' << formatting::format_complex(Energy) << ' '
+                  << Info.TruncationError() << ' ' << Info.KeptEntropy() << ' '
+                  << Solver_.LastFidelityLoss() << ' ' << Solver_.LastIter() << ' '
+                  << Solver_.LastTol() << '\n';
+      PerStepFile.flush();
+   }
 }
 
 int main(int argc, char** argv)
@@ -1050,9 +1064,16 @@ int main(int argc, char** argv)
 
       std::cout.precision(getenv_or_default("MP_PRECISION", 14));
       std::cerr.precision(getenv_or_default("MP_PRECISION", 14));
+      PerStepFile.precision(getenv_or_default("MP_PRECISION", 14));
 
       if (!Quiet)
          print_preamble(std::cout, argc, argv);
+
+      if (PerStep)
+      {
+         print_preamble(PerStepFile, argc, argv);
+         PerStepFile << "#Time #Step #SweepNum #States #Energy #Trunc #Entropy #Fidelity #Iter #Tol\n";
+      }
 
       std::cout << "Starting iDMRG.  Hamiltonian = " << HamStr << '\n';
       std::cout << "Wavefunction = " << FName << std::endl;


### PR DESCRIPTION
## Summary

- Add shared `MP_BENCHFILE` filename handling with date/time substitutions, next-unused numbering via `%n`/`%3n`, and append modes using leading `+`/`++`.
- Move existing finite DMRG tools to the shared opener while preserving their per-step output format.
- Extend per-step `MP_BENCHFILE` output to the active `mp-idmrg-s3e` tool, including the existing `P/R/Q/L/F` step label.

## Notes

Before this change, `MP_BENCHFILE` was active only in `mp-dmrg`, `mp-dmrg-2site`, and `mp-dmrg-3s`. This PR also wires it into `mp-idmrg-s3e`. The old `mp-idmrg-ee.cpp` source is not part of the built tool set on `main`; the corresponding environment-expansion iDMRG support should be forward-ported on the `dmrg-ee` branch later.

## Validation

- `cmake -S . -B /tmp/mptk-benchfile-build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMPTK_ENABLE_IPO=OFF`
- `cmake --build /tmp/mptk-benchfile-build --target mp-dmrg mp-dmrg-2site mp-dmrg-3s mp-idmrg-s3e -j 4`
- `git diff --check`
- Smoke-tested `%2n` and `%C-%n` filename expansion through `mp-dmrg --help` and `mp-idmrg-s3e --help` with `MP_BENCHFILE` set.