### PR TITLE
[codex] Use NamedEnumeration for eigensolver choices

### DIFF
--- a/common/namedenum.h
+++ b/common/namedenum.h
@@ -35,10 +35,14 @@
 //    static constexpr std::array<char const*, 3> Names = { "some", "enumeration", "elements" };
 // };
 //
+// String construction is case-insensitive.
+//
 
+#include "common/stringutil.h"
 #include <array>
+#include <stdexcept>
 #include <string>
-#include <exception>
+#include <vector>
 
 #if !defined(MPTOOLKIT_COMMON_NAMEDENUM_H)
 #define MPTOOLKIT_COMMON_NAMEDENUM_H
@@ -75,7 +79,12 @@ class NamedEnumeration : public Traits
       NamedEnumeration& operator--() { e = static_cast<Enum>(e-1); return *this; }
       const NamedEnumeration& operator*() const { return *this; }
 
+      // returns a comma-separated list of the enumeration names
       static std::string ListAvailable();
+      static std::string ListAll();
+
+      // returns an array of the enumeration names
+      static std::vector<std::string> EnumerateAll();
 
       std::string Name() const { return Traits::Names[e]; }
 
@@ -99,12 +108,29 @@ std::string NamedEnumeration<Traits>::ListAvailable()
 }
 
 template <typename Traits>
-NamedEnumeration<Traits>::NamedEnumeration(std::string Name)
+std::string NamedEnumeration<Traits>::ListAll()
 {
-   std::transform(Name.begin(), Name.end(), Name.begin(), [](unsigned char c){ return std::tolower(c); });
+   return ListAvailable();
+}
+
+template <typename Traits>
+std::vector<std::string> NamedEnumeration<Traits>::EnumerateAll()
+{
+   std::vector<std::string> Result;
+   Result.reserve(NamedEnumeration::size());
    for (auto a : NamedEnumeration())
    {
-      if (a.Name() == Name)
+      Result.push_back(a.Name());
+   }
+   return Result;
+}
+
+template <typename Traits>
+NamedEnumeration<Traits>::NamedEnumeration(std::string Name)
+{
+   for (auto a : NamedEnumeration())
+   {
+      if (IEquals(a.Name(), Name))
       {
          e = a.e;
          return;

--- a/mp-algorithms/eigensolver.cpp
+++ b/mp-algorithms/eigensolver.cpp
@@ -22,7 +22,6 @@
 #include "mp-algorithms/arnoldi.h"
 #include "mp-algorithms/gmres.h"
 #include "mp-algorithms/davidson.h"
-#include "common/stringutil.h"
 
 #include "mps/packunpack.h"
 
@@ -76,59 +75,19 @@ struct MPSMultiplyShift
 LocalEigensolver::Solver
 LocalEigensolver::SolverFromStr(std::string Str)
 {
-   Str = ToLowerCopy(Str);
-   if (Str == "lanczos")
-      return Solver::Lanczos;
-   else if (Str == "arnoldi")
-      return Solver::Arnoldi;
-   else if (Str == "arnoldi-smallest")
-      return Solver::ArnoldiSmallest;
-   else if (Str == "arnoldi-lowest")
-      return Solver::ArnoldiLowest;
-   else if (Str == "davidson")
-      return Solver::Davidson;
-   else if (Str == "shift-invert")
-      return Solver::ShiftInvert;
-   else if (Str == "shift-invert-direct")
-      return Solver::ShiftInvertDirect;
-   else if (Str == "davidson")
-      return Solver::Davidson;
-   else if (Str == "davidson-target")
-      return Solver::DavidsonTarget;
-   else if (Str == "davidson-max-overlap")
-      return Solver::DavidsonMaxOverlap;
-   return Solver::InvalidSolver;
+   return Solver(Str);
 }
 
 std::string
 LocalEigensolver::SolverStr(LocalEigensolver::Solver s)
 {
-   if (s == Solver::Lanczos)
-      return "lanczos";
-   else if (s == Solver::Arnoldi)
-      return "arnoldi";
-   else if (s == Solver::Davidson)
-      return "davidson";
-   else if (s == Solver::ShiftInvert)
-      return "shift-Invert";
-   else if (s == Solver::ShiftInvertDirect)
-      return "shift-invert-direct";
-   else if (s == Solver::Davidson)
-      return "davidson";
-   else if (s == Solver::DavidsonTarget)
-      return "davidson-target";
-   else if (s == Solver::DavidsonMaxOverlap)
-      return "davidson-max-overlap";
-   return "Invalid Solver";
+   return s.Name();
 }
 
 std::vector<std::string>
 LocalEigensolver::EnumerateSolvers()
 {
-   std::vector<std::string> Result;
-   for (int s = int(Solver::Lanczos); s <= int(Solver::LastSolver); ++s)
-      Result.push_back(SolverStr(Solver(s)));
-   return Result;
+   return Solver::EnumerateAll();
 }
 
 LocalEigensolver::LocalEigensolver(Solver s)
@@ -404,7 +363,7 @@ LocalEigensolver::Solve(StateComponent& C,
       }
       else
       {
-         PANIC("Unsupported solver")(SolverStr(Solver_));
+         PANIC("Unsupported solver")(Solver_.Name());
       }
    }
 

--- a/mp-algorithms/eigensolver.h
+++ b/mp-algorithms/eigensolver.h
@@ -22,15 +22,27 @@
 
 #include "mps/state_component.h"
 #include "mpo/operator_component.h"
+#include "common/namedenum.h"
 #include "common/statistics.h"
+#include <vector>
 
 class LocalEigensolver
 {
    public:
-      // FIXME: this could use common/namedenum.h
-      enum class Solver { InvalidSolver, Lanczos, Arnoldi, ArnoldiSmallest, ArnoldiLowest, ShiftInvert, ShiftInvertDirect,
-                             Davidson, DavidsonTarget, DavidsonMaxOverlap,
-                             LastSolver = DavidsonMaxOverlap};
+      struct SolverTraits
+      {
+         enum Enum { Lanczos, Arnoldi, ArnoldiSmallest, ArnoldiLowest, ShiftInvert,
+                     ShiftInvertDirect, Davidson, DavidsonTarget, DavidsonMaxOverlap };
+         static constexpr std::array<char const*, 9> Names = {
+            "lanczos", "arnoldi", "arnoldi-smallest", "arnoldi-lowest",
+            "shift-invert", "shift-invert-direct", "davidson", "davidson-target",
+            "davidson-max-overlap"
+         };
+         static constexpr Enum Default = Lanczos;
+         static constexpr char const* StaticName = "eigensolver";
+      };
+
+      using Solver = NamedEnumeration<SolverTraits>;
 
       static Solver SolverFromStr(std::string str);
 
@@ -65,9 +77,9 @@ class LocalEigensolver
       int Verbose;
 
       Solver GetSolver() const { return Solver_; }
-      std::string GetSolverStr() const { return SolverStr(Solver_); }
+      std::string GetSolverStr() const { return Solver_.Name(); }
       void SetSolver(Solver s);
-      void SetSolver(std::string const& s) { this->SetSolver(SolverFromStr(s)); }
+      void SetSolver(std::string const& s) { this->SetSolver(Solver(s)); }
 
       // For solver-specific parameters, we probably should provide a generic format.
       // Since we only have one solver-specific parameter we just have a special case for now.

--- a/mp/mp-dmrg-2site.cpp
+++ b/mp/mp-dmrg-2site.cpp
@@ -32,7 +32,6 @@
 #include "common/statistics.h"
 #include "common/formatting.h"
 #include "common/prog_opt_accum.h"
-#include "common/stringutil.h"
 #include "interface/inittemp.h"
 #include <fstream>
 
@@ -258,8 +257,8 @@ int main(int argc, char** argv)
          ("sweeps,s", prog_opt::value(&NumSweeps),
           FormatDefault("Number of half-sweeps to perform", NumSweeps).c_str())
          ("Solver,S", prog_opt::value(&Solver),
-          FormatDefault("Eigensoler to use ("
-			+ JoinStrings(LocalEigensolver::EnumerateSolvers(), ", ") + ")", Solver).c_str())
+          FormatDefault("Eigensolver to use; choices are "
+                        + LocalEigensolver::Solver::ListAvailable(), Solver).c_str())
          ("orthogonal", prog_opt::value<std::vector<std::string> >(),
           "force the wavefunction to be orthogonal to this state ***NOT YET IMPLEMENTED***")
          ("oversample", prog_opt::value(&Oversampling.Scale), FormatDefault("For random SVD, oversample by this factor", Oversampling.Scale).c_str())

--- a/mp/mp-dmrg-3s.cpp
+++ b/mp/mp-dmrg-3s.cpp
@@ -32,7 +32,6 @@
 #include "common/statistics.h"
 #include "common/formatting.h"
 #include "common/prog_opt_accum.h"
-#include "common/stringutil.h"
 #include "interface/inittemp.h"
 #include <fstream>
 
@@ -212,8 +211,8 @@ int main(int argc, char** argv)
          ("sweeps,s", prog_opt::value(&NumSweeps),
           FormatDefault("Number of half-sweeps to perform", NumSweeps).c_str())
          ("Solver,S", prog_opt::value(&Solver),
-          FormatDefault("Eigensoler to use ("
-			+ JoinStrings(LocalEigensolver::EnumerateSolvers(), ", ") + ")", Solver).c_str())
+          FormatDefault("Eigensolver to use; choices are "
+                        + LocalEigensolver::Solver::ListAvailable(), Solver).c_str())
          ("orthogonal", prog_opt::value<std::vector<std::string> >(),
           "force the wavefunction to be orthogonal to this state ***NOT YET IMPLEMENTED***")
          ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),

--- a/mp/mp-dmrg.cpp
+++ b/mp/mp-dmrg.cpp
@@ -32,7 +32,6 @@
 #include "common/statistics.h"
 #include "common/formatting.h"
 #include "common/prog_opt_accum.h"
-#include "common/stringutil.h"
 #include "interface/inittemp.h"
 #include <fstream>
 
@@ -232,8 +231,8 @@ int main(int argc, char** argv)
          ("sweeps,s", prog_opt::value(&NumSweeps),
           FormatDefault("Number of half-sweeps to perform", NumSweeps).c_str())
          ("Solver,S", prog_opt::value(&Solver),
-          FormatDefault("Eigensoler to use ("
-			+ JoinStrings(LocalEigensolver::EnumerateSolvers(), ", ") + ")", Solver).c_str())
+          FormatDefault("Eigensolver to use; choices are "
+                        + LocalEigensolver::Solver::ListAvailable(), Solver).c_str())
          ("orthogonal", prog_opt::value<std::vector<std::string> >(),
           "force the wavefunction to be orthogonal to this state ***NOT YET IMPLEMENTED***")
          ("oversample", prog_opt::value(&Oversampling.Scale), FormatDefault("For random SVD, oversample by this factor", Oversampling.Scale).c_str())

--- a/mp/mp-icdmrg.cpp
+++ b/mp/mp-icdmrg.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("tolerance for GMRES linear solver for the initial H matrix elements", GMRESTol).c_str())
 	 ("solver", prog_opt::value<std::string>(),
-	  "Eigensolver to use.  Supported values are lanzcos [default], arnoldi, arnoldi-lowest, shift-invert")
+	  ("Eigensolver to use; choices are " + LocalEigensolver::Solver::ListAvailable()).c_str())
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),
 	  "For the shift-invert solver, the target energy")
 

--- a/mp/mp-idmrg-ee.cpp
+++ b/mp/mp-idmrg-ee.cpp
@@ -953,7 +953,7 @@ int main(int argc, char** argv)
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("tolerance for GMRES linear solver for the initial H matrix elements", GMRESTol).c_str())
 	 ("solver", prog_opt::value<std::string>(),
-	  "Eigensolver to use.  Supported values are lanzcos [default], arnoldi, arnoldi-lowest, shift-invert")
+	  ("Eigensolver to use; choices are " + LocalEigensolver::Solver::ListAvailable()).c_str())
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),
 	  "For the shift-invert solver, the target energy")
 

--- a/mp/mp-idmrg-s3e.cpp
+++ b/mp/mp-idmrg-s3e.cpp
@@ -1024,7 +1024,7 @@ int main(int argc, char** argv)
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("tolerance for GMRES linear solver for the initial H matrix elements", GMRESTol).c_str())
 	 ("solver", prog_opt::value<std::string>(),
-	  "Eigensolver to use.  Supported values are lanzcos [default], arnoldi, arnoldi-lowest, shift-invert")
+	  ("Eigensolver to use; choices are " + LocalEigensolver::Solver::ListAvailable()).c_str())
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),
 	  "For the shift-invert solver, the target energy")
 


### PR DESCRIPTION
## Summary

- Replace the hand-written `LocalEigensolver` solver string table with a `NamedEnumeration`-backed solver type.
- Add `NamedEnumeration::EnumerateAll()` and a `ListAll()` alias while preserving existing `ListAvailable()` users.
- Keep compatibility wrappers for `SolverFromStr`, `SolverStr`, and `EnumerateSolvers`, but make invalid solver names fail through the `NamedEnumeration` constructor with a clear choices list.
- Fix eigensolver help text so it no longer lists `Invalid Solver`, `shift-Invert`, or the `lanzcos` typo.

## Notes

The functional solver set is unchanged: `lanczos`, `arnoldi`, `arnoldi-smallest`, `arnoldi-lowest`, `shift-invert`, `shift-invert-direct`, `davidson`, `davidson-target`, and `davidson-max-overlap`.

## Validation

- `cmake -S . -B /tmp/mptk-namedenum-build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DMPTK_ENABLE_IPO=OFF`
- `cmake --build /tmp/mptk-namedenum-build --target mp-dmrg mp-dmrg-2site mp-dmrg-3s mp-idmrg-s3e -j 4`
- `cmake --build /tmp/mptk-namedenum-build --target tools -j 4`
- `git diff --check`
- Checked `mp-dmrg --help` and `mp-idmrg-s3e --help` for the corrected solver list.