### PR TITLE
[codex] Allow AKLT idmrg tests to soft-fail

### DIFF
--- a/scripts/mptk-stress-test
+++ b/scripts/mptk-stress-test
@@ -233,6 +233,15 @@ for ((i = 1; ; ++i)); do
         printf '[%s/%s] ' "$i" "$iterations"
     fi
     if "${cmd[@]}" >"$log_file" 2>&1; then
+        if grep -q '^SOFTFAIL ' "$log_file"; then
+            failures=$((failures + 1))
+            printf 'SOFTFAIL (%s)\n' "$log_file"
+            printf 'SOFTFAIL %04d %s\n' "$i" "$log_file" | tee -a "$summary_file" >>"$failures_file"
+            if (( fail_fast )); then
+                break
+            fi
+            continue
+        fi
         passes=$((passes + 1))
         printf 'PASS\n'
         printf 'PASS %04d\n' "$i" >>"$summary_file"

--- a/scripts/mptk-stress-test
+++ b/scripts/mptk-stress-test
@@ -169,16 +169,20 @@ print_summary() {
 
     end_epoch=$(date +%s)
     elapsed=$((end_epoch - start_epoch))
-    total=$((passes + failures))
+    total=$((passes + failures + soft_failures))
 
     printf '\n'
-    printf 'Overall summary: %d total, %d passed, %d failed\n' \
+    printf 'Overall summary: %d total, %d passed, %d failed' \
         "$total" "$passes" "$failures" | tee -a "$summary_file"
+    if (( soft_failures )); then
+        printf ', %d soft-failed' "$soft_failures" | tee -a "$summary_file"
+    fi
+    printf '\n' | tee -a "$summary_file"
     if (( interrupted )); then
         printf 'Stopped by interrupt\n' | tee -a "$summary_file"
     fi
     printf 'Elapsed: %ds\n' "$elapsed" | tee -a "$summary_file"
-    if (( failures )); then
+    if (( failures || soft_failures )); then
         printf 'Failure logs:\n' | tee -a "$summary_file"
         cat "$failures_file"
     fi
@@ -207,6 +211,7 @@ printf '\n' | tee -a "$summary_file"
 
 passes=0
 failures=0
+soft_failures=0
 start_epoch=$(date +%s)
 
 for ((i = 1; ; ++i)); do
@@ -234,7 +239,7 @@ for ((i = 1; ; ++i)); do
     fi
     if "${cmd[@]}" >"$log_file" 2>&1; then
         if grep -q '^SOFTFAIL ' "$log_file"; then
-            failures=$((failures + 1))
+            soft_failures=$((soft_failures + 1))
             printf 'SOFTFAIL (%s)\n' "$log_file"
             printf 'SOFTFAIL %04d %s\n' "$i" "$log_file" | tee -a "$summary_file" >>"$failures_file"
             if (( fail_fast )); then
@@ -264,6 +269,6 @@ for ((i = 1; ; ++i)); do
     fi
 done
 
-if (( failures )); then
+if (( failures || soft_failures )); then
     exit 1
 fi

--- a/scripts/mptk-test
+++ b/scripts/mptk-test
@@ -128,8 +128,10 @@ status=0
 total_tests=0
 total_passed=0
 total_failed=0
+total_soft_failed=0
 suite_errors=0
 failures=()
+soft_failures=()
 first_suite=1
 for suite in "${suites[@]}"; do
     cmd=(python3 "${repo_root}/tests/run_suite.py" "$suite" --bin-dir "$bin_dir")
@@ -158,16 +160,24 @@ for suite in "${suites[@]}"; do
     printf '%s\n' "$output"
 
     summary_line=$(printf '%s\n' "$output" | grep '^Summary: ' | tail -n 1 || true)
-    if [[ $summary_line =~ Summary:\ ([0-9]+)\ total,\ ([0-9]+)\ passed,\ ([0-9]+)\ failed ]]; then
+    if [[ $summary_line =~ Summary:\ ([0-9]+)\ total,\ ([0-9]+)\ passed,\ ([0-9]+)\ failed(,\ ([0-9]+)\ soft-failed)? ]]; then
         total_tests=$((total_tests + BASH_REMATCH[1]))
         total_passed=$((total_passed + BASH_REMATCH[2]))
         total_failed=$((total_failed + BASH_REMATCH[3]))
+        if [[ -n ${BASH_REMATCH[5]:-} ]]; then
+            total_soft_failed=$((total_soft_failed + BASH_REMATCH[5]))
+        fi
     fi
 
     while IFS= read -r line; do
         test_name=${line#FAIL }
         failures+=("$(basename "$suite"):$test_name")
     done < <(printf '%s\n' "$output" | grep '^FAIL ' || true)
+
+    while IFS= read -r line; do
+        test_name=${line#SOFTFAIL }
+        soft_failures+=("$(basename "$suite"):$test_name")
+    done < <(printf '%s\n' "$output" | grep '^SOFTFAIL ' || true)
 
     if (( suite_status != 0 )) && ! printf '%s\n' "$output" | grep -q '^FAIL '; then
         suite_errors=$((suite_errors + 1))
@@ -178,6 +188,9 @@ done
 printf '\n'
 printf 'Overall summary: %d total, %d passed, %d failed' \
     "$total_tests" "$total_passed" "$total_failed"
+if (( total_soft_failed )); then
+    printf ', %d soft-failed' "$total_soft_failed"
+fi
 if (( suite_errors )); then
     printf ', %d suite errors' "$suite_errors"
 fi
@@ -185,6 +198,12 @@ printf '\n'
 if ((${#failures[@]})); then
     printf 'Overall failures:\n'
     for failure in "${failures[@]}"; do
+        printf -- '- %s\n' "$failure"
+    done
+fi
+if ((${#soft_failures[@]})); then
+    printf 'Overall allowed failures:\n'
+    for failure in "${soft_failures[@]}"; do
         printf -- '- %s\n' "$failure"
     done
 fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,6 +71,11 @@ Useful runner flags:
   temporary directory
 - `--dump-ir`: print the normalized suite representation for one suite
 
+Suites can temporarily mark a test with `allow_failure: "reason"` when a known
+issue should remain visible without blocking CI. These tests still run. A
+failure is reported as `SOFTFAIL`, included in the suite and overall summaries,
+and does not make the runner exit nonzero.
+
 Layout:
 
 - `run_suite.py`: the test runner
@@ -124,6 +129,7 @@ Stress-test behavior:
 - default log directory is `/tmp/mptk-stress-<suite>-<timestamp>-<pid>/`
 - `summary.txt` records pass/fail by iteration
 - failed iteration logs are kept automatically
+- `SOFTFAIL` iterations are treated as stress failures so their logs are kept
 - passing iteration logs are deleted unless `--keep-all-logs` is given
 - `--fail-fast` stops on the first failure
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -127,7 +127,7 @@ Common stress-test patterns:
 Stress-test behavior:
 
 - default log directory is `/tmp/mptk-stress-<suite>-<timestamp>-<pid>/`
-- `summary.txt` records pass/fail by iteration
+- `summary.txt` records pass/fail/soft-fail by iteration
 - failed iteration logs are kept automatically
 - `SOFTFAIL` iterations are treated as stress failures so their logs are kept
 - passing iteration logs are deleted unless `--keep-all-logs` is given

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -1507,7 +1507,7 @@ class SuiteRunner:
             reason = allow_failure_reason(self.tests[name])
             try:
                 self.run_test(name)
-            except Exception as exc:  # pragma: no cover - suite failure path
+            except SuiteError as exc:  # pragma: no cover - suite failure path
                 if reason is not None:
                     soft_failures.append((name, reason, str(exc)))
                     print(f"SOFTFAIL {name}")
@@ -1516,6 +1516,11 @@ class SuiteRunner:
                     failures.append((name, str(exc)))
                     print(f"FAIL {name}")
                 print(str(exc))
+            except Exception as exc:  # pragma: no cover - unexpected runner failure path
+                message = f"Unexpected runner error: {type(exc).__name__}: {exc}"
+                failures.append((name, message))
+                print(f"FAIL {name}")
+                print(message)
             else:
                 if reason is not None:
                     allowed_passes.append((name, reason))

--- a/tests/run_suite.py
+++ b/tests/run_suite.py
@@ -64,6 +64,23 @@ class SuiteError(RuntimeError):
     pass
 
 
+def allow_failure_reason(test_spec: dict[str, Any]) -> str | None:
+    if "allow_failure" not in test_spec:
+        return None
+    marker = test_spec["allow_failure"]
+    if marker is None or marker is False:
+        return None
+    if isinstance(marker, str):
+        return marker or "allowed failure"
+    if isinstance(marker, dict):
+        reason = marker.get("reason")
+        issue = marker.get("issue")
+        parts = [str(part) for part in (issue, reason) if part]
+        if parts:
+            return ": ".join(parts)
+    return "allowed failure"
+
+
 def strip_ansi(text: str) -> str:
     return ANSI_ESCAPE_RE.sub("", text)
 
@@ -1484,20 +1501,45 @@ class SuiteRunner:
         if unknown:
             raise SuiteError(f"Unknown test(s): {', '.join(unknown)}")
         failures: list[tuple[str, str]] = []
+        soft_failures: list[tuple[str, str, str]] = []
+        allowed_passes: list[tuple[str, str]] = []
         for name in test_names:
+            reason = allow_failure_reason(self.tests[name])
             try:
                 self.run_test(name)
-                print(f"PASS {name}")
             except Exception as exc:  # pragma: no cover - suite failure path
-                failures.append((name, str(exc)))
-                print(f"FAIL {name}")
+                if reason is not None:
+                    soft_failures.append((name, reason, str(exc)))
+                    print(f"SOFTFAIL {name}")
+                    print(f"Allowed failure: {reason}")
+                else:
+                    failures.append((name, str(exc)))
+                    print(f"FAIL {name}")
                 print(str(exc))
-        passed = len(test_names) - len(failures)
-        print(f"Summary: {len(test_names)} total, {passed} passed, {len(failures)} failed")
+            else:
+                if reason is not None:
+                    allowed_passes.append((name, reason))
+                    print(f"PASS {name} (allow_failure: {reason})")
+                else:
+                    print(f"PASS {name}")
+        passed = len(test_names) - len(failures) - len(soft_failures)
+        summary = f"Summary: {len(test_names)} total, {passed} passed, {len(failures)} failed"
+        if soft_failures:
+            summary += f", {len(soft_failures)} soft-failed"
+        print(summary)
         if failures:
             print("Failed tests:")
             for name, _message in failures:
                 print(f"- {name}")
+        if soft_failures:
+            print("Allowed failures:")
+            for name, reason, _message in soft_failures:
+                print(f"- {name}: {reason}")
+        if allowed_passes:
+            print("Allow-failure tests that passed:")
+            for name, reason in allowed_passes:
+                print(f"- {name}: {reason}")
+        if failures:
             return 1
         return 0
 

--- a/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
+++ b/tests/suites/spinchain-aklt-spt-uc1-rerun.yaml
@@ -73,6 +73,9 @@ fixtures:
 
 tests:
   rerunning_single_site_aklt_dmrg_preserves_exact_energy_and_spt_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground_uc1_rerun
     expect:
       - attr_float:

--- a/tests/suites/spinchain-aklt-spt-uc1.yaml
+++ b/tests/suites/spinchain-aklt-spt-uc1.yaml
@@ -41,6 +41,9 @@ fixtures:
 
 tests:
   aklt_single_site_ground_state_has_the_expected_energy_density:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground_uc1
     expect:
       - attr_text:
@@ -52,6 +55,9 @@ tests:
           abs: 1e-5
 
   aklt_single_site_ground_state_shows_the_expected_spt_xz_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground_uc1
     expect:
       - aux_algebra_commutator_real:
@@ -66,6 +72,9 @@ tests:
           abs: 1e-5
 
   aklt_single_site_ground_state_shows_the_expected_spt_xy_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground_uc1
     expect:
       - aux_algebra_commutator_real:
@@ -80,6 +89,9 @@ tests:
           abs: 1e-5
 
   aklt_single_site_ground_state_shows_the_expected_spt_yz_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground_uc1
     expect:
       - aux_algebra_commutator_real:

--- a/tests/suites/spinchain-aklt-spt.yaml
+++ b/tests/suites/spinchain-aklt-spt.yaml
@@ -41,6 +41,9 @@ fixtures:
 
 tests:
   aklt_ground_state_has_the_expected_energy_density:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground
     expect:
       - attr_text:
@@ -52,6 +55,9 @@ tests:
           abs: 1e-5
 
   aklt_ground_state_shows_the_expected_spt_xz_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground
     expect:
       - aux_algebra_commutator_real:
@@ -66,6 +72,9 @@ tests:
           abs: 1e-5
 
   aklt_ground_state_shows_the_expected_spt_xy_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground
     expect:
       - aux_algebra_commutator_real:
@@ -80,6 +89,9 @@ tests:
           abs: 1e-5
 
   aklt_ground_state_shows_the_expected_spt_yz_projective_phase:
+    allow_failure: >-
+      Issue #104: mp-idmrg-s3e AKLT convergence is unstable pending the new
+      idmrg cleanup.
     use: aklt_ground
     expect:
       - aux_algebra_commutator_real:


### PR DESCRIPTION
## Summary

Adds an `allow_failure` marker to the declarative integration runner so known flaky/unstable tests still execute but report as `SOFTFAIL` instead of blocking CI.

Marks the AKLT `mp-idmrg-s3e` suites affected by issue #104 with that marker, so the failures remain visible in the suite and overall summaries while the longer-term idmrg cleanup happens separately. The stress-test helper still treats `SOFTFAIL` iterations as stress failures so manual flake-hunting retains logs.

## Validation

- `python3 -m py_compile tests/run_suite.py`
- `bash -n scripts/mptk-test`
- `bash -n scripts/mptk-stress-test`
- `git diff --check`
- Fresh CMake Release configure with OpenMP enabled, then:
  - `cmake --build <build-dir> --target testexponential --parallel 2`
  - `ctest --test-dir <build-dir> --output-on-failure`
  - `cmake --build <build-dir> --target test-integration --parallel 2`

Fresh integration result: `182 total, 181 passed, 0 failed, 1 soft-failed`. The soft failure was the expected issue #104 AKLT one-site case.