### PR TITLE
[codex] Fix IBC correlation unit-cell sizing

### DIFF
--- a/mp/mp-ibc-correlation.cpp
+++ b/mp/mp-ibc-correlation.cpp
@@ -28,6 +28,7 @@
 #include "common/prog_options.h"
 #include "parser/number-parser.h"
 #include "lattice/infinite-parser.h"
+#include <iterator>
 
 namespace prog_opt = boost::program_options;
 
@@ -215,8 +216,13 @@ int main(int argc, char** argv)
 
       // If UCSize is not specified, then we set it to the left boundary unit
       // cell size.
-      if (UCSize = -1)
-         UCSize = Psi1.left().size();
+      if (UCSize == -1)
+         UCSize = std::ssize(Psi1.left());
+      if (UCSize <= 0)
+      {
+         std::cerr << "fatal: --ucsize must be positive." << std::endl;
+         return 1;
+      }
       
       if (vm.count("string"))
       {

--- a/tests/recipes/mptoolkit-probes.yaml
+++ b/tests/recipes/mptoolkit-probes.yaml
@@ -105,6 +105,19 @@ recipes:
         pattern: "{time} {x} %(float:value)"
         capture: value
 
+  ibc_correlation_ucsize_real:
+    probe: mp-ibc-correlation --quiet --real -w {prefix} -t {timestep} -n {num_steps} --xmin {xmin} -x {xmax} --ucsize {ucsize}
+    defaults:
+      num_steps: 0
+      xmin: 0
+      xmax: 0
+      x: 0
+      time: "-0.0"
+    extract:
+      line_pattern:
+        pattern: "{time} {x} %(float:value)"
+        capture: value
+
   aux_algebra_commutator_real:
     probe: mp-aux-algebra -w {state} -l {lattice} --quiet {operator1} {operator2}
     defaults:

--- a/tests/suites/spinchain-ibc-dynamics.yaml
+++ b/tests/suites/spinchain-ibc-dynamics.yaml
@@ -35,6 +35,33 @@ fixtures:
           approx: 1.0
           abs: 1e-12
 
+  lat_plain:
+    run: spinchain -o lat_plain
+    outputs:
+      lattice: lat_plain
+
+  infinite_neel2_plain:
+    from: lat_plain
+    run: mp-construct -l lat_plain -o psi_plain 0.5:-0.5
+    outputs:
+      state: psi_plain
+
+  ibc_neel2_plain:
+    from: infinite_neel2_plain
+    run: mp-ibc-create psi_plain -o ibc_plain --boundary-lambda
+    outputs:
+      state: ibc_plain
+
+  ibc_neel2_plain_correlation_prefix:
+    from: ibc_neel2_plain
+    steps:
+      - run: cp ibc_plain out_plain.b-0.0
+        outputs:
+          initial_state_negzero: out_plain.b-0.0
+      - run: cp ibc_plain out_plain.b0.0
+        outputs:
+          initial_state_zero: out_plain.b0.0
+
   ibc_neel2_tdvp_identity:
     from: ibc_neel2
     steps:
@@ -222,4 +249,22 @@ tests:
           x: 2
           time: "0.1"
           approx: 1.0
+          abs: 1e-12
+
+  ibc_correlation_honors_explicit_ucsize:
+    use: ibc_neel2_plain_correlation_prefix
+    expect:
+      # The no-symmetry Neel product state is orthogonal to a one-site
+      # translate. Before this check, mp-ibc-correlation accidentally assigned
+      # UCSize = -1 instead of testing it, so --ucsize 1 was ignored and this
+      # x=1 sample used the default two-site wavefunction unit cell instead.
+      - ibc_correlation_ucsize_real:
+          prefix: out_plain
+          timestep: "0-0.1i"
+          num_steps: 0
+          xmax: 1
+          x: 1
+          ucsize: 1
+          time: "-0.0"
+          approx: 0.0
           abs: 1e-12

--- a/wavefunction/ibc.cpp
+++ b/wavefunction/ibc.cpp
@@ -19,6 +19,7 @@
 // ENDHEADER
 
 #include "ibc.h"
+#include "common/numerics.h"
 #include "mpwavefunction.h"
 #include "tensor/tensor_eigen.h"
 #include "mp-algorithms/transfer.h"
@@ -698,8 +699,8 @@ get_boundary_transfer_eigenvectors(IBCWavefunction const& Psi1, ProductMPO const
 
    // Compensate for the boundary contributions to the phase for the boundaries
    // which have been incorporated into the window.
-   E *= std::pow(OverlapL, IndexLeft / LeftSize);
-   F *= std::pow(OverlapR, IndexRight / RightSize);
+   E *= std::pow(OverlapL, numerics::divp(IndexLeft, LeftSize).quot);
+   F *= std::pow(OverlapR, numerics::divp(IndexRight, RightSize).quot);
 
    return std::make_tuple(E, F);
 }


### PR DESCRIPTION
Fix two focused IBC arithmetic issues on top of PR #103. mp-ibc-correlation now tests whether -`-ucsize` was unspecified instead of assigning `UCSize = -1`, validates that explicit values are positive, and defaults through `std::ssize()` in signed context. The IBC boundary phase compensation now uses positive-remainder division for negative window offsets. A no-symmetry Neel regression checks that `--ucsize` 1 is honored instead of silently using the two-site wavefunction unit cell.