### PR TITLE
[codex] Use SVD for DMRG 3S truncation

### DIFF
--- a/mp-algorithms/expansion.cpp
+++ b/mp-algorithms/expansion.cpp
@@ -995,7 +995,10 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
    MatrixOperator Lambda = ExpandBasis1(C);
 #endif
 
-   MatrixOperator Rho = scalar_prod(herm(Lambda), Lambda);
+   BasisList MixBasis(C.GetSymmetryList());
+   MixBasis.push_back(Lambda.TransformsAs());
+   std::vector<MatrixOperator> SVDTerms;
+   SVDTerms.push_back(Lambda);
    if (MixFactor > 0)
    {
 #if defined(SSC)
@@ -1003,8 +1006,8 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
 #else
       StateComponent RH = contract_from_right(herm(H), C, RightHam, herm(C));
 #endif
-      MatrixOperator RhoMix;
-      MatrixOperator RhoL = scalar_prod(Lambda, herm(Lambda));
+      std::vector<MatrixOperator> MixTerms;
+      double MixTrace = 0.0;
 
       // Skip the identity and the Hamiltonian
       for (unsigned i = 1; i < RH.size()-1; ++i)
@@ -1012,19 +1015,34 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
          double Prefactor = norm_frob_sq(herm(Lambda) * LeftHam[i]);
          if (Prefactor == 0)
             Prefactor = 1;
-         RhoMix += Prefactor * triple_prod(herm(RH[i]), Rho, RH[i]);
-	 //TRACE(i)(Prefactor);
+         MatrixOperator Term = std::sqrt(Prefactor) * (Lambda * RH[i]);
+         MixTrace += norm_frob_sq(Term);
+         MixTerms.push_back(std::move(Term));
       }
       // check for a zero mixing term - can happen if there are no interactions that span
       // the current bond
-      double RhoTrace = trace(RhoMix).real();
-      if (RhoTrace != 0)
-         Rho += (MixFactor / RhoTrace) * RhoMix;
+      if (MixTrace != 0)
+      {
+         double const MixScale = std::sqrt(MixFactor / MixTrace);
+         for (auto const& Term : MixTerms)
+         {
+            MatrixOperator ScaledTerm = MixScale * Term;
+            MixBasis.push_back(ScaledTerm.TransformsAs());
+            SVDTerms.push_back(std::move(ScaledTerm));
+         }
+      }
    }
 
-   DensityMatrix<MatrixOperator> DM(Rho);
+   StateComponent TruncationTensor(MixBasis, Lambda.Basis1(), Lambda.Basis2());
+   for (unsigned i = 0; i < SVDTerms.size(); ++i)
+   {
+      CHECK_EQUAL(TruncationTensor.LocalBasis()[i], SVDTerms[i].TransformsAs());
+      TruncationTensor[i] = std::move(SVDTerms[i]);
+   }
+
+   CMatSVD DM(ReshapeBasis1(TruncationTensor), CMatSVD::Right);
    //DM.DensityMatrixReport(std::cout);
-   DensityMatrix<MatrixOperator>::const_iterator DMPivot =
+   CMatSVD::const_iterator DMPivot =
       TruncateFixTruncationErrorRelative(DM.begin(), DM.end(),
                                          States,
                                          Info);
@@ -1032,7 +1050,7 @@ SubspaceExpandBasis1(StateComponent& C, OperatorComponent const& H, StateCompone
    std::list<EigenInfo> KeptStates(DM.begin(), DMPivot);
    std::list<EigenInfo> DiscardStates(DMPivot, DM.end());
 
-   MatrixOperator UKeep = DM.ConstructTruncator(KeptStates.begin(), KeptStates.end());
+   MatrixOperator UKeep = DM.ConstructRightVectors(KeptStates.begin(), KeptStates.end());
    Lambda = Lambda * herm(UKeep);
 
    //TRACE(Lambda);
@@ -1063,35 +1081,53 @@ SubspaceExpandBasis2(StateComponent& C, OperatorComponent const& H, StateCompone
 {
    MatrixOperator Lambda = ExpandBasis2(C);
 
-   MatrixOperator Rho = scalar_prod(Lambda, herm(Lambda));
+   BasisList MixBasis(C.GetSymmetryList());
+   MixBasis.push_back(Lambda.TransformsAs());
+   std::vector<MatrixOperator> SVDTerms;
+   SVDTerms.push_back(Lambda);
    if (MixFactor > 0)
    {
       StateComponent LH = contract_from_left(H, herm(C), LeftHam, C);
-      MatrixOperator RhoMix;
-
-      MatrixOperator RhoR = scalar_prod(herm(Lambda), Lambda);
+      std::vector<MatrixOperator> MixTerms;
+      double MixTrace = 0.0;
 
       for (unsigned i = 1; i < LH.size()-1; ++i)
       {
          double Prefactor = norm_frob_sq(Lambda * RightHam[i]);
          if (Prefactor == 0)
             Prefactor = 1;
-         RhoMix += Prefactor * triple_prod(LH[i], Rho, herm(LH[i]));
-	 //	 TRACE(i)(Prefactor);
+         MatrixOperator Term = std::sqrt(Prefactor) * (LH[i] * Lambda);
+         MixTrace += norm_frob_sq(Term);
+         MixTerms.push_back(std::move(Term));
       }
-      double RhoTrace = trace(RhoMix).real();
-      if (RhoTrace != 0)
-         Rho += (MixFactor / RhoTrace) * RhoMix;
+      if (MixTrace != 0)
+      {
+         double const MixScale = std::sqrt(MixFactor / MixTrace);
+         for (auto const& Term : MixTerms)
+         {
+            MatrixOperator ScaledTerm = MixScale * Term;
+            MixBasis.push_back(ScaledTerm.TransformsAs());
+            SVDTerms.push_back(std::move(ScaledTerm));
+         }
+      }
    }
-   DensityMatrix<MatrixOperator> DM(Rho);
-   DensityMatrix<MatrixOperator>::const_iterator DMPivot =
+
+   StateComponent TruncationTensor(MixBasis, Lambda.Basis1(), Lambda.Basis2());
+   for (unsigned i = 0; i < SVDTerms.size(); ++i)
+   {
+      CHECK_EQUAL(TruncationTensor.LocalBasis()[i], SVDTerms[i].TransformsAs());
+      TruncationTensor[i] = std::move(SVDTerms[i]);
+   }
+
+   CMatSVD DM(ReshapeBasis2(TruncationTensor), CMatSVD::Left);
+   CMatSVD::const_iterator DMPivot =
       TruncateFixTruncationErrorRelative(DM.begin(), DM.end(),
                                          States,
                                          Info);
    std::list<EigenInfo> KeptStates(DM.begin(), DMPivot);
    std::list<EigenInfo> DiscardStates(DMPivot, DM.end());
 
-   MatrixOperator UKeep = DM.ConstructTruncator(KeptStates.begin(), KeptStates.end());
+   MatrixOperator UKeep = adjoint(DM.ConstructLeftVectors(KeptStates.begin(), KeptStates.end()));
 
    Lambda = UKeep * Lambda;
    C = prod(C, herm(UKeep));

--- a/mp/mp-dmrg-3s.cpp
+++ b/mp/mp-dmrg-3s.cpp
@@ -201,9 +201,9 @@ int main(int argc, char** argv)
          ("trunc,r", prog_opt::value<double>(&TruncCutoff),
           FormatDefault("Truncation error cutoff", TruncCutoff).c_str())
          ("eigen-cutoff,d", prog_opt::value(&EigenCutoff),
-          FormatDefault("Cutoff threshold for density matrix eigenvalues", EigenCutoff).c_str())
+          FormatDefault("Cutoff threshold for density matrix weights", EigenCutoff).c_str())
          ("mix-factor", prog_opt::value(&MixFactor),
-          FormatDefault("Mixing coefficient for the density matrix", MixFactor).c_str())
+          FormatDefault("Mixing coefficient for the 3S expansion", MixFactor).c_str())
          ("evolve", prog_opt::value(&EvolveDelta),
           "Instead of Lanczos, do imaginary time evolution with this timestep")
          ("maxiter", prog_opt::value<int>(&NumIter),
@@ -318,7 +318,7 @@ int main(int argc, char** argv)
       }
       std::cout << MyStates << '\n';
 
-      std::cout << "Density matrix mixing coefficient: " << MixFactor << std::endl;
+      std::cout << "3S expansion mixing coefficient: " << MixFactor << std::endl;
       std::cout << "Number of Lanczos iterations: " << NumIter << std::endl;
       std::cout << "Number of half-sweeps: " << NumSweeps << std::endl;
       std::cout << "Using solver: " << Solver << std::endl;


### PR DESCRIPTION
## Summary

Replace the finite `mp-dmrg-3s` reduced-density truncation construction with an equivalent SVD of the stacked 3S expansion terms.

The new path builds the wavefunction and scaled 3S mixing terms as an auxiliary `StateComponent`, reshapes it with the existing `ReshapeBasis1` / `ReshapeBasis2` conventions, and keeps the relevant one-sided singular vectors via `CMatSVD`. This avoids explicitly forming the density matrix while preserving the same SVD weights used by the truncation machinery.

The command-line/help text now refers to SVD weights and 3S expansion SVD mixing rather than density-matrix eigenvalues/mixing.

## Validation

Focused integration:

```text
scripts/mptk-test --bin-dir /tmp/mptk-dmrg-s3-svd --test dmrg_3s_legacy_sweeps_path_converges_and_formats_real_energy_cleanly spinchain-finite-algorithms
```

Result: passed.

## Spectrum equivalence check

Temporary local instrumentation compared the old density-matrix eigenvalues and new SVD weights inside the same expansion call on `hubbardholstein-u1su2 -N 8`.

Two-sweep dump summary:

```text
basis1: max abs sum diff 1.1e-15, max abs top-entry diff 8.9e-16
basis2: max abs sum diff 2.0e-15, max abs top-entry diff 1.0e-15
```

The mix traces also matched at roundoff, so the standard `ReshapeBasis1` / `ReshapeBasis2` normalization is consistent with the old density construction.

## Benchmarks

Setup for both cases:

```text
hubbardholstein-u1su2
mp-random -u 32 -q 16,0 -s 123
schedule: 16*1.41421356237..1024x2
H = lat:(H_t+0.5*H_w+(0.8*H_U+sqrt(0.2)*H_g))
finite check: lat:fsup(0,16,H_t+0.5*H_w+(0.8*H_U+sqrt(0.2)*H_g))
```

Results:

| case | old density 3S | new SVD 3S | old/new speedup | mp-dmrg |
| --- | ---: | ---: | ---: | ---: |
| N=3 | 166.10s | 142.03s | 1.17x | 118.54s |
| N=8 | 633.59s | 279.68s | 2.27x | 217.29s |

Old/new 3S final energy deltas:

```text
N=3: -2.13e-14
N=8:  3.91e-14
```

All `LastEnergy` values agreed with explicit finite `fsup` expectations to roughly `1e-13` to `6e-13`.