### PR TITLE
[codex] Tune iDMRG boundary inverse shift

### DIFF
--- a/mp/mp-idmrg-3s.cpp
+++ b/mp/mp-idmrg-3s.cpp
@@ -119,7 +119,7 @@ InvertDiagonal(LinearAlgebra::DiagonalMatrix<double> const& D, double Tol = 1E-1
    return Result;
 }
 
-double const Alpha = 100;
+double BoundaryInverseAlpha = 1e-3;
 
 // function to calculate
 // (D1 * U) * Inverse(D2)
@@ -195,9 +195,9 @@ Solve_D_U_DInv(RealDiagonalOperator const& D, MatrixOperator const& U, RealDiago
          int Dim2 = E.Basis1().dim(J.index2());
 
          LinearAlgebra::DiagonalMatrix<double>
-            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, Alpha);
+            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, BoundaryInverseAlpha);
          LinearAlgebra::DiagonalMatrix<double>
-            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, Alpha);
+            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, BoundaryInverseAlpha);
 
          LinearAlgebra::Matrix<std::complex<double>> Component =
             DD * (*J) * InvertDiagonal(EE, iTol);
@@ -221,9 +221,9 @@ Solve_DInv_U_D(RealDiagonalOperator const& D, MatrixOperator const& U, RealDiago
          int Dim2 = E.Basis1().dim(J.index2());
 
          LinearAlgebra::DiagonalMatrix<double>
-            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, Alpha);
+            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, BoundaryInverseAlpha);
          LinearAlgebra::DiagonalMatrix<double>
-            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, Alpha);
+            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, BoundaryInverseAlpha);
 
          LinearAlgebra::Matrix<std::complex<double>> Component =
             InvertDiagonal(DD, iTol) * (*J) * EE;
@@ -921,6 +921,8 @@ int main(int argc, char** argv)
          ("seed", prog_opt::value<unsigned long>(), "random seed")
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("tolerance for GMRES linear solver for the initial H matrix elements", GMRESTol).c_str())
+         ("boundary-inverse-alpha", prog_opt::value(&BoundaryInverseAlpha),
+          FormatDefault("Regularizing shift for boundary lambda inversion", BoundaryInverseAlpha).c_str())
 	 ("solver", prog_opt::value<std::string>(),
 	  ("Eigensolver to use; choices are " + LocalEigensolver::Solver::ListAvailable()).c_str())
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),

--- a/mp/mp-idmrg-s3e.cpp
+++ b/mp/mp-idmrg-s3e.cpp
@@ -118,7 +118,7 @@ InvertDiagonal(LinearAlgebra::DiagonalMatrix<double> const& D, double Tol = 1E-1
    return Result;
 }
 
-double const Alpha = 100;
+double BoundaryInverseAlpha = 1e-3;
 
 // function to calculate
 // (D1 * U) * Inverse(D2)
@@ -194,9 +194,9 @@ Solve_D_U_DInv(RealDiagonalOperator const& D, MatrixOperator const& U, RealDiago
          int Dim2 = E.Basis1().dim(J.index2());
 
          LinearAlgebra::DiagonalMatrix<double>
-            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, Alpha);
+            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, BoundaryInverseAlpha);
          LinearAlgebra::DiagonalMatrix<double>
-            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, Alpha);
+            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, BoundaryInverseAlpha);
 
          LinearAlgebra::Matrix<std::complex<double>> Component =
             DD * (*J) * InvertDiagonal(EE, iTol);
@@ -220,9 +220,9 @@ Solve_DInv_U_D(RealDiagonalOperator const& D, MatrixOperator const& U, RealDiago
          int Dim2 = E.Basis1().dim(J.index2());
 
          LinearAlgebra::DiagonalMatrix<double>
-            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, Alpha);
+            DD = D(J.index1(), J.index1()) + LinearAlgebra::DiagonalMatrix<double>(Dim1, Dim1, BoundaryInverseAlpha);
          LinearAlgebra::DiagonalMatrix<double>
-            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, Alpha);
+            EE = E(J.index2(), J.index2()) + LinearAlgebra::DiagonalMatrix<double>(Dim2, Dim2, BoundaryInverseAlpha);
 
          LinearAlgebra::Matrix<std::complex<double>> Component =
             InvertDiagonal(DD, iTol) * (*J) * EE;
@@ -1034,6 +1034,8 @@ int main(int argc, char** argv)
          ("seed", prog_opt::value<unsigned long>(), "random seed")
          ("gmrestol", prog_opt::value(&GMRESTol),
           FormatDefault("tolerance for GMRES linear solver for the initial H matrix elements", GMRESTol).c_str())
+         ("boundary-inverse-alpha", prog_opt::value(&BoundaryInverseAlpha),
+          FormatDefault("Regularizing shift for boundary lambda inversion", BoundaryInverseAlpha).c_str())
 	 ("solver", prog_opt::value<std::string>(),
 	  ("Eigensolver to use; choices are " + LocalEigensolver::Solver::ListAvailable()).c_str())
 	 ("shift-invert-energy", prog_opt::value(&ShiftInvertEnergy),


### PR DESCRIPTION
## Summary

Set the iDMRG boundary lambda-map regularization shift to a smaller default and expose it as a command-line option.

- Replace the hard-coded boundary inverse shift `Alpha = 100` with `BoundaryInverseAlpha = 1e-3`.
- Add `--boundary-inverse-alpha` to `mp-idmrg-s3e`, `mp-idmrg-3s`, and the `mp-idmrg-ee` sibling implementation.
- Apply the shift consistently in both `D*U*E^{-1}` and `D^{-1}*U*E` boundary map helpers.

## Rationale

Recent ramp tests found that the old value `100` is much larger than needed. The overall accuracy is not very sensitive to this parameter, but values around `1e-3` to `1e-4` gave a small and consistent improvement during ramping. Keeping it configurable preserves the previous behavior for comparisons.

## Validation

- `cmake --build build-codex --target mp-idmrg-s3e mp-idmrg-3s`
- Confirmed both built tools show `--boundary-inverse-alpha` with `[default 0.001]` in `--help`.
- `git diff --check -- mp/mp-idmrg-3s.cpp mp/mp-idmrg-s3e.cpp mp/mp-idmrg-ee.cpp`

The build still emits the pre-existing missing-return warnings in `PartialSolveSimpleMPO_Left`.
